### PR TITLE
Add resolve and reject to js template

### DIFF
--- a/scaffolding/templates/action.go.md
+++ b/scaffolding/templates/action.go.md
@@ -10,8 +10,6 @@
 
 ## Return
 
-## Exceptions
-
 ## Usage
 
 [code-example=<%= _.kebabCase(action) %>]

--- a/scaffolding/templates/action.js.md
+++ b/scaffolding/templates/action.js.md
@@ -13,7 +13,9 @@
 
 ### arg2
 
-## Return
+## Resolve
+
+## Reject
 
 ## Usage
 

--- a/scaffolding/templates/index.md
+++ b/scaffolding/templates/index.md
@@ -3,7 +3,7 @@ layout: sdk.html
 algolia: true
 title: <%= action %>
 description: changeme
-order: changeme
+order: 200
 ---
 
 # <%= action %>

--- a/scaffolding/templates/usage-snippets/usage.java
+++ b/scaffolding/templates/usage-snippets/usage.java
@@ -1,5 +1,5 @@
 try {
-    kuzzle.get<%= _.camelCase(controller) %>().<%= action %>();
+    kuzzle.get<%= _.upperFirst(_.camelCase(controller)) %>().<%= action %>();
     System.out.println("Success");
 } catch (KuzzleException e) {
     System.err.println(e.getMessage());


### PR DESCRIPTION
## What does this PR do?

In Javascript we care more about how the promise will resolve or reject (and what it will resolve/reject) than the return value.  
This PR replace the `Return` section by `Resolve` and `Reject` in the scaffolding tool.

## Other changes

 - Remove Exception section for Go
 - Replace the default Return section by Resolve and Reject for Javascript
 - Add default order so metalsmith will use alphabetical order by default