### PR TITLE
KZL 495 - Update c++ snippet with lambda

### DIFF
--- a/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
@@ -10,7 +10,7 @@ order: 200
 
 Adds a listener to an event.  
 When an event is triggered, listeners are triggered in the order in which they were added.  
-Theses listener will receive a `const std::string` as only argument. This string is a JSON payload representing the event.
+Theses listener will receive a `const std::string` as argument. This string is a JSON payload representing the event.
 
 ## Signature
 
@@ -46,7 +46,7 @@ ERROR
 ### **listener**
 
 A c++11 lambda which take a `const std::string`
-Internally `EventListener` is a typedef on `const std::function<void(const std::string)>`.
+`EventListener` is defined as `const std::function<void(const std::string)>`.
 
 ## Return
 

--- a/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
@@ -9,12 +9,13 @@ order: 200
 # addListener
 
 Adds a listener to an event.  
-When an event is triggered, listeners are triggered in the order in which they were added.
+When an event is triggered, listeners are triggered in the order in which they were added.  
+Theses listener will receive a `const std::string` as only argument. This string is a JSON payload representing the event.
 
 ## Signature
 
 ```cpp
-kuzzleio::KuzzleEventEmitter* addListener(kuzzleio::Event event, kuzzleio::EventListener* listener)
+kuzzleio::KuzzleEventEmitter* addListener(kuzzleio::Event event, EventListener* listener)
 ```
 
 ## Arguments
@@ -22,7 +23,7 @@ kuzzleio::KuzzleEventEmitter* addListener(kuzzleio::Event event, kuzzleio::Event
 | Argument   | Type                      | Description                                                                                            | Required |
 | ---------- | ------------------------- | ------------------------------------------------------------------------------------------------------ | -------- |
 | `event`    | Event                     | An enum representing the listened [event]({{ site_base_path }}sdk-reference/essentials/event-handling) | yes      |
-| `listener` | kuzzleio::EventListener\* | A pointer to an instance of an `EventListener`                                                         | yes      |
+| `listener` | EventListener\* | A pointer to a c++11 lambda                                           | yes      |
 
 ### **event**
 
@@ -44,17 +45,8 @@ ERROR
 
 ### **listener**
 
-An instance of a class that inherits from `kuzzleio::EventListener`.  
-This class must implement the following method:
-
-```cpp
-class MyListener : public kuzzleio::EventListener {
-  public:
-    void trigger(char* json_payload) const {
-      // Do something with the json payload
-    }
-};
-```
+A c++11 lambda which take a `const std::string`
+Internally `EventListener` is a typedef on `const std::function<void(const std::string)>`.
 
 ## Return
 

--- a/src/sdk-reference/cpp/1/kuzzle/add-listener/snippets/add-listener.cpp
+++ b/src/sdk-reference/cpp/1/kuzzle/add-listener/snippets/add-listener.cpp
@@ -1,4 +1,8 @@
-MyListener *listener = new MyListener();
-MyListener *other_listener = new MyListener();
+EventListener listener = [](const std::string payload) {
+  std::cout << payload << std::endl;
+};
+EventListener other_listener = [](const std::string payload) {
+  std::cerr << payload << std::endl;
+};
 
-kuzzle->addListener(CONNECTED, listener)->addListener(CONNECTED, other_listener);
+kuzzle->addListener(CONNECTED, &listener)->addListener(CONNECTED, &other_listener);

--- a/test/templates/without-connect.tpl.cpp
+++ b/test/templates/without-connect.tpl.cpp
@@ -8,14 +8,6 @@
 #include "index.hpp"
 #include "realtime.hpp"
 #include "kuzzle.hpp"
-#include "listeners.hpp"
-
-class MyListener : public kuzzleio::EventListener {
- public:
-    void trigger(const std::string& jsonResponse) {
-      std::cout << jsonResponse << std::endl;
-    }
-};
 
 int main() {
   std::string hostname = "kuzzle";


### PR DESCRIPTION

## What does this PR do?

This PR update the c++ snippet to use c++11 lambda instead of listener class.  

### How should this be manually tested?

  - Step 1 : Run cpp tests: `bash run-snippet-tests.sh -n -p src/sdk-reference/cpp/1`
