### PR TITLE
sort by title if page orders are equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,17 @@ metalsmith
     for (const file of Object.values(files)) {
       if (file.ancestry && file.ancestry.children) {
         const
-          orderedPages = file.ancestry.children.sort((a,b) => a.order - b.order),
+          orderedPages = file.ancestry.children.sort((a,b) => {
+            if (a.order === b.order) {
+              if (a.title === b.title) {
+                return 0;
+              }
+
+              return a.title < b.title ? -1 : 1;
+            }
+
+            return a.order - b.order;
+          }),
           href = '/' + file.src.split('/').slice(0,-1).join('/'),
           redirect = '/' + orderedPages[0].src.split('/').slice(0,-1).join('/');
 


### PR DESCRIPTION
## What does this PR do?

Without this fix, pages with the same `order` value are displayed at random (for this purpose, an arbitrary large order value was already attributed to pages without one).

Instead, the sort should fall back to title values if 2 pages have the same order value.

Before:

![screenshot from 2018-10-03 12-08-38](https://user-images.githubusercontent.com/12997967/46404324-1cfe6c80-c705-11e8-9111-f7a56b36064c.png)


After:

![screenshot from 2018-10-03 12-08-29](https://user-images.githubusercontent.com/12997967/46404331-2091f380-c705-11e8-93a6-6e411848a768.png)
