### PR TITLE
Fix left nav on sdk pages when section has no parent

### DIFF
--- a/src/assets/stylesheets/_config.scss
+++ b/src/assets/stylesheets/_config.scss
@@ -73,4 +73,4 @@ $md-code-color: #282c34;
 $md-keyboard-background: #fcfcfc;
 $md-keyboard-color: #555555;
 
-$md-code-background-inline: #4e5459;
+$md-code-background-inline: #757575;

--- a/src/assets/stylesheets/layout/_nav.scss
+++ b/src/assets/stylesheets/layout/_nav.scss
@@ -41,7 +41,7 @@
     padding: 0;
     list-style: none;
 
-    .sub-menu:not(.no-section) {
+    .sub-menu:not(.no-parent) {
       padding-left: 16px;
     }
   }

--- a/src/assets/stylesheets/layout/_nav.scss
+++ b/src/assets/stylesheets/layout/_nav.scss
@@ -41,7 +41,7 @@
     padding: 0;
     list-style: none;
 
-    .sub-menu {
+    .sub-menu:not(.no-section) {
       padding-left: 16px;
     }
   }

--- a/src/assets/stylesheets/libs/prism.css
+++ b/src/assets/stylesheets/libs/prism.css
@@ -6,10 +6,6 @@ https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+css+cli
  * @author Rose Pritchard
  */
 
-pre[class*='language-'] {
-  display: none;
-}
-
 code[class*='language-'],
 pre[class*='language-'] {
   color: #ccc;

--- a/src/templates/partials/navMobile.html
+++ b/src/templates/partials/navMobile.html
@@ -6,7 +6,7 @@
         Kuzzle documentation
     </span>
 </label>
-{{#if (eq this.layout "sdk.html")}}
+{{#if (eq this.layout "sdk.html.hbs")}}
   <div class="selector-container mobile-only">
     <select class="language-selector" style="width:56%"></select>
     <select class="version-selector" style="width:22%"></select>  

--- a/src/templates/partials/nav_sdk.html
+++ b/src/templates/partials/nav_sdk.html
@@ -4,10 +4,12 @@
     <!-- Render item list -->
     <ul class="md-nav__list" data-md-scrollfix>
       {{#each ancestry.parent.ancestry.siblings as |parent|}}
-        <li class="md-nav__item">
-            <a class="md-nav__link"  href="{{ ../site_base_path }}{{ parent.path }}">{{displayTitle parent}}</a>
-        </li>
-          <ul class="md-nav__list sub-menu">
+        {{#if parent.title}}
+          <li class="md-nav__item">
+              <a class="md-nav__link"  href="{{ ../site_base_path }}{{ parent.path }}">{{displayTitle parent}}</a>
+          </li>
+        {{/if}}
+          <ul class="md-nav__list sub-menu {{#if (not parent.title)}}no-section{{/if}}">
             {{#each parent.ancestry.children as |children|}}
               {{#if (eq ../../ancestry.parent.path parent.path)}}
                 {{#if children.title}}

--- a/src/templates/partials/nav_sdk.html
+++ b/src/templates/partials/nav_sdk.html
@@ -9,7 +9,7 @@
               <a class="md-nav__link"  href="{{ ../site_base_path }}{{ parent.path }}">{{displayTitle parent}}</a>
           </li>
         {{/if}}
-          <ul class="md-nav__list sub-menu {{#if (not parent.title)}}no-section{{/if}}">
+          <ul class="md-nav__list sub-menu {{#if (not parent.title)}}no-parent{{/if}}">
             {{#each parent.ancestry.children as |children|}}
               {{#if (eq ../../ancestry.parent.path parent.path)}}
                 {{#if children.title}}


### PR DESCRIPTION
## What does this PR do?
Before : 
![before](https://user-images.githubusercontent.com/3192870/46525000-bacf7400-c88a-11e8-92d5-c37e88364f74.png) 
After : 
![after](https://user-images.githubusercontent.com/3192870/46525700-9f656880-c88c-11e8-9e1c-b498edf4e6ac.png)


### How should this be manually tested?
https://deploy-preview-60--kuzzle-doc-v2.netlify.com/sdk-reference/js/6/essentials/

### Other changes
 * fix version and languages selector on mobile
 * remove display none css rules for "Usage" snippets 
 * change inline code background color for a more lighter one

