### PR TITLE
API migration: security controller

### DIFF
--- a/src/api/1/controller-security/create-credentials/index.md
+++ b/src/api/1/controller-security/create-credentials/index.md
@@ -1,0 +1,82 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createCredentials
+---
+
+# createCredentials
+
+{{{since "1.0.0"}}}
+
+Create authentication credentials for a user.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>/_create
+Method: POST  
+Body:
+```
+
+```js
+{
+  // example for the "local" authentication strategy
+  "username": "MyUser",
+  "password": "MyPassword"
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>",
+  "body": {
+    // example for the "local" authentication strategy
+    "username": "MyUser",
+    "password": "MyPassword"
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user unique [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid)
+* `strategy`: name of the target authentication strategy for the credentials
+
+---
+
+## Body properties
+
+The credentials to send. The expected properties depend on the target authentication strategy.
+
+---
+
+## Response
+
+The result content depends on the authentication strategy. 
+
+Example with the `local` authentication strategy:
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "createCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": {
+    "username": "MyUser",
+    "kuid": "<kuid>"
+  }
+}
+```

--- a/src/api/1/controller-security/create-first-admin/index.md
+++ b/src/api/1/controller-security/create-first-admin/index.md
@@ -1,0 +1,108 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createFirstAdmin
+---
+
+# createFirstAdmin
+
+{{{since "1.0.0"}}}
+
+Create a Kuzzle administrator account, only if none exist.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/<kuid>/_createFirstAdmin[?reset]
+Alternate URL: http://kuzzle:7512/_createFirstAdmin[?reset]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "content": {
+    // administrator information (optional)
+  },
+  "credentials": {
+    // for example, with the "local" authentication strategy:
+    "local": {
+      "username": "userAdmin",
+      "password": "myPassword"
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createFirstAdmin",
+  "body": {
+    "content": {
+      // administrator information (optional)               
+    },
+    "credentials": {
+      // for example, with the "local" authentication strategy:
+      "local": {
+        "username": "userAdmin",
+        "password": "myPassword"
+      }
+    }
+  },
+  // optional
+  "reset": <boolean>,
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `_id`: specify the administror [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid), instead of generating a random identifier
+* `reset` (boolean): if true, restricted rights are applied to the `anonymous` and `default` roles (by default, these roles don't have restriction). 
+
+---
+
+## Body properties
+
+* `content`: administrator additional information. Can be left empty.
+* `credentials`: describe how the new administrator can be authenticated. This object must contain one or multiple properties, named after the target authentication strategy to use. Each one of these properties are objects containing the credentials information, corresponding to that authentication strategy
+
+---
+
+## Response
+
+Return information about the newly created administratory:
+
+* `_id`: administrator kuid
+* `_source`: administrator user document, contains all properties set in the `content` body argument, but also the list of attributed `profileIds`. That list is initialized with the `admin` profile
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "controller": "security",
+  "action": "createFirstAdmin",
+  "volatile": {},
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",                  // The kuzzle user identifier
+    "_source": {
+      "name": "John Doe",
+      "profileIds": [
+        "admin"
+      ]
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/create-first-admin/index.md
+++ b/src/api/1/controller-security/create-first-admin/index.md
@@ -18,7 +18,7 @@ Create a Kuzzle administrator account, only if none exist.
 
 ```http
 URL: http://kuzzle:7512/<kuid>/_createFirstAdmin[?reset]
-Alternate URL: http://kuzzle:7512/_createFirstAdmin[?reset]
+URL(2): http://kuzzle:7512/_createFirstAdmin[?reset]
 Method: POST  
 Body:
 ```

--- a/src/api/1/controller-security/create-first-admin/index.md
+++ b/src/api/1/controller-security/create-first-admin/index.md
@@ -68,8 +68,8 @@ Body:
 
 ### Optional:
 
-* `_id`: specify the administror [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid), instead of generating a random identifier
-* `reset` (boolean): if true, restricted rights are applied to the `anonymous` and `default` roles (by default, these roles don't have restriction). 
+* `_id`: specify the administror [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid), instead of letting Kuzzle generate a random identifier.
+* `reset` (boolean): if true, restricted rights are applied to the `anonymous` and `default` roles (by default, these roles don't have any restriction). 
 
 ---
 
@@ -82,7 +82,7 @@ Body:
 
 ## Response
 
-Return information about the newly created administratory:
+Return information about the newly created administrator:
 
 * `_id`: administrator kuid
 * `_source`: administrator user document, contains all properties set in the `content` body argument, but also the list of attributed `profileIds`. That list is initialized with the `admin` profile

--- a/src/api/1/controller-security/create-or-replace-profile/index.md
+++ b/src/api/1/controller-security/create-or-replace-profile/index.md
@@ -1,0 +1,125 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createOrReplaceProfile
+---
+
+# createOrReplaceProfile
+
+{{{since "1.0.0"}}}
+
+Create a new profile or, if the provided profile identifier already exists, replace it.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/<_id>[?refresh=wait_for]
+Method: PUT
+Body:
+```
+
+```js
+{
+  "policies": [
+    {
+      "roleId": "<roleId>"
+    },
+    {
+      "roleId": "<anotherRoleId>",
+      "restrictedTo": [
+        {
+          "index": "<index>"
+        },
+        {
+          "index": "<index>",
+          "collections": [
+            "<coll1>",
+            "<coll2>"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createOrReplaceProfile",
+  "_id": "<profileId>",              
+  "body": {
+    "policies": [
+      {
+        "roleId": "<anotherRoleId>"
+      },
+      {
+        "roleId": "<roleId>",
+        "restrictedTo": [
+          {
+            "index": "<index>"
+          },
+          {
+            "index": "<index>",
+            "collections": [
+              "<coll1>",
+              "<coll2>"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: profile identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced profile is indexed
+
+---
+
+## Body properties
+
+* `policies`: [profile definition]({{site_base_path}}guide/1/essentials/security/#defining-profiles)
+
+---
+
+## Response
+
+Return an object with the new profile modification status:
+
+* `_id`: created/replaced profile identifier
+* `_source`: profile content
+* `created`: if `true`, the profile has been created. Otherwise, it has been replaced
+* `version`: updated version number of the profile
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "result": {
+    "_id": "<profileId>",
+    "_version": 1,
+    "_source": {
+      // new profile content
+    }
+    "created": true
+  },
+  "requestId": "<request unique identifier>",
+  "controller": "security",
+  "action": "createOrReplaceProfile"
+}
+```

--- a/src/api/1/controller-security/create-or-replace-role/index.md
+++ b/src/api/1/controller-security/create-or-replace-role/index.md
@@ -1,0 +1,105 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createOrReplaceRole
+---
+
+# createOrReplaceRole
+
+{{{since "1.0.0"}}}
+
+Create a new role or, if the provided role identifier already exists, replace it.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/<_id>[?refresh=wait_for]
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "controllers": {
+    "*": {
+      "actions": {
+        "*": true
+      }
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createOrReplaceRole",
+  "_id": "<roleId>",
+  "body": {
+    "controllers": {
+      "*": {
+        "actions": {
+          "*": true
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: role identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the created/replaced role is indexed
+
+---
+
+## Body properties
+
+* `controllers`: [role definition]({{ site_base_path }}guide/1/essentials/security/#defining-roles)
+
+---
+
+## Response
+
+Return the role creation/replacement status:
+
+* `_id`: created/replaced role identifier
+* `_source`: role definition
+* `created`: if true, the role has been created. Otherwise, it has been replaced
+* `version`: updated role version number
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "result": {
+    "_id": "<roleId>",
+    "_version": 1,
+    "created": true,
+    "_source": {
+      "controllers": {
+        "*": {
+          "actions": {
+            "*": true
+          }
+        }
+      }
+    }
+  }
+  "requestId": "<unique request identifier>",
+  "controller": "security",
+  "action": "createOrReplaceRole"
+}
+```

--- a/src/api/1/controller-security/create-profile/index.md
+++ b/src/api/1/controller-security/create-profile/index.md
@@ -1,0 +1,126 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createProfile
+---
+
+
+# createProfile
+
+{{{since "1.0.0"}}}
+
+Create a new profile.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/<_id>/_create[?refresh=wait_for]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "policies": [
+    {
+      "roleId": "<roleId>"
+    },
+    {
+      "roleId": "<roleId>",
+      "restrictedTo": [
+        {
+          "index": "<index>"
+        },
+        {
+          "index": "<index>",
+          "collections": [
+            "<coll1>",
+            "<coll2>"
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createProfile",
+  "_id": "<profileId>",
+  "body": {
+    "policies": [
+      {
+        "roleId": "<roleId>"
+      },
+      {
+        "roleId": "<roleId>",
+        "restrictedTo": [
+          {
+            "index": "<index>"
+          },
+          {
+            "index": "<index>",
+            "collections": [
+              "<coll1>",
+              "<coll2>"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: new profile identifier. An error is returned if the profile already exists
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the created profile is indexed
+
+---
+
+## Body properties
+
+* `policies`: [profile definition]({{site_base_path}}guide/1/essentials/security/#defining-profiles)
+
+---
+
+## Response
+
+Return an object with the new profile creation status:
+
+* `_id`: created profile identifier
+* `_source`: profile content
+* `created`: always `true`
+* `version`: always `1`
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<profileId>",
+    "_version": 1,
+    "created": true,
+    "_source": {
+      // new profile content
+    }
+  },
+  "requestId": "<unique request identifier>",
+  "controller": "security",
+  "action": "createProfile"
+}
+```

--- a/src/api/1/controller-security/create-restricted-user/index.md
+++ b/src/api/1/controller-security/create-restricted-user/index.md
@@ -1,0 +1,111 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createRestrictedUser
+---
+
+# createRestrictedUser
+
+{{{since "1.0.0"}}}
+
+Create a new user in Kuzzle, with a preset list of security profiles.
+
+The list of security profiles attributed to restricted users is fixed, and must be configured in the [Kuzzle configuration file]({{ site_base_path }}guide/1/essentials/configuration/).
+
+This method allows users with limited rights to create other accounts, but blocks them from creating accounts with unwanted privileges (e.g. an anonymous user creating his own account).
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>/_createRestricted[?refresh=wait_for] 
+Alternate URL: http://kuzzle:7512/users/_createRestricted[?refresh=wait_for]
+Method: POST
+Body:
+```
+
+```js
+{
+  "content": {
+    // user additional information (optional)
+    "fullname": "John Doe"
+  },
+  "credentials": {
+    // example with the "local" authentication strategy
+    "local": {
+      username: "jdoe",
+      password: "foobar"
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createRestrictedUser",
+  "_id": "<kuid>",
+  "body": {
+    "content": {
+      "fullname": "John Doe"
+    },
+    "credentials": {
+      // example with the "local" authentication strategy
+      "local": {
+        username: "jdoe",
+        password: "foobar"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
+
+---
+
+## Body properties
+
+* `content`: user additional information. Can be left empty.
+* `credentials`: describe how the new user can be authenticated. This object contains any number of properties, named after the target authentication strategy to use. Each one of these properties are objects containing the credentials information, corresponding to that authentication strategy. If left empty, the new user is created but cannot be authenticated.
+
+---
+
+## Response
+
+Return the restricted user creation status:
+
+* `_id`: new user kuid
+* `_source`: new user content and attributed profiles
+* `created`: always true
+* `version`: always 1
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "security",
+  "action": "createRestrictedUser",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",
+    "_source": {
+      "profileIds": ["<profileId>"],
+      "fullname": "John Doe"
+    },
+    "_version": 1,
+    "created": true
+  }
+}
+```

--- a/src/api/1/controller-security/create-restricted-user/index.md
+++ b/src/api/1/controller-security/create-restricted-user/index.md
@@ -22,7 +22,7 @@ This method allows users with limited rights to create other accounts, but block
 
 ```http
 URL: http://kuzzle:7512/users/<_id>/_createRestricted[?refresh=wait_for] 
-Alternate URL: http://kuzzle:7512/users/_createRestricted[?refresh=wait_for]
+URL(2): http://kuzzle:7512/users/_createRestricted[?refresh=wait_for]
 Method: POST
 Body:
 ```

--- a/src/api/1/controller-security/create-role/index.md
+++ b/src/api/1/controller-security/create-role/index.md
@@ -1,0 +1,106 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createRole
+---
+
+
+# createRole
+
+{{{since "1.0.0"}}}
+
+Create a new role.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/<_id>/_create[?refresh=wait_for]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "controllers": {
+    "*": {
+      "actions": {
+        "*": true
+      }
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createRole",
+  "_id": "<roleId>",
+  "body": {
+    "controllers": {
+      "*": {
+        "actions": {
+          "*": true
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: role identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the created role is indexed
+
+---
+
+## Body properties
+
+* `controllers`: [role definition]({{ site_base_path }}guide/1/essentials/security/#defining-roles)
+
+---
+
+## Response
+
+Return the role creation/replacement status:
+
+* `_id`: created/replaced role identifier
+* `_source`: role definition
+* `created`: always true
+* `version`: always 1
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<roleId>",
+    "_version": 1,
+    "created": true,
+    "_source": {
+      "controllers": {
+        "*": {
+          "actions": {
+            "*": true
+          }
+        }
+      }
+    }
+  }
+  "requestId": "<unique request identifier>",
+  "controller": "security",
+  "action": "createRole"
+}
+```

--- a/src/api/1/controller-security/create-user/index.md
+++ b/src/api/1/controller-security/create-user/index.md
@@ -1,0 +1,115 @@
+---
+layout: full.html.hbs
+algolia: true
+title: createUser
+---
+
+
+# createUser
+
+{{{since "1.0.0"}}}
+
+Create a new user.
+
+The body contains the user data and must have the following properties:
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>/_create[?refresh=wait_for]
+Alternate URL: http://kuzzle:7512/users/_create[?refresh=wait_for]
+Method: POST
+Body:
+```
+
+```js
+{
+  "content": {
+    "profileIds": ["<profileId>"],
+    // additional user properties (optional)
+    "fullname": "John Doe"
+  },
+  "credentials": {
+    // example with the "local" authentication strategy
+    "local": {
+      username: "jdoe",
+      password: "foobar"
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "createUser",
+  "_id": "<kuid>",
+  "body": {
+    "content": {
+      "profileIds": ["<profileId>"],
+      // additional user properties (optional)
+      "fullname": "John Doe"
+    },
+    "credentials": {
+      // example with the "local" authentication strategy
+      "local": {
+        username: "jdoe",
+        password: "foobar"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier). An error is returned if the provided identifier already exists. If not provided, a random kuid is automatically generated.
+
+---
+
+## Body properties
+
+* `content`: an object describing the user. Properties:
+  * `profileIds`: an array of security profiles attributed to the user
+  * any other property: optional additional user information
+* `credentials`: describe how the new user can be authenticated. This object contains any number of properties, named after the target authentication strategy to use. Each one of these properties are objects containing the credentials information, corresponding to that authentication strategy. If left empty, the new user is created but cannot be authenticated.
+
+---
+
+## Response
+
+Return the user creation status:
+
+* `_id`: new user kuid
+* `_source`: new user content and attributed profiles
+* `created`: always true
+* `version`: always 1
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "security",
+  "action": "createUser",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",
+    "_source": {
+      "profileIds": ["<profileId>"],
+      "fullname": "John Doe"
+    },
+    "_version": 1,
+    "created": true
+  }
+}
+```

--- a/src/api/1/controller-security/create-user/index.md
+++ b/src/api/1/controller-security/create-user/index.md
@@ -21,7 +21,7 @@ The body contains the user data and must have the following properties:
 
 ```http
 URL: http://kuzzle:7512/users/<_id>/_create[?refresh=wait_for]
-Alternate URL: http://kuzzle:7512/users/_create[?refresh=wait_for]
+URL(2): http://kuzzle:7512/users/_create[?refresh=wait_for]
 Method: POST
 Body:
 ```

--- a/src/api/1/controller-security/delete-credentials/index.md
+++ b/src/api/1/controller-security/delete-credentials/index.md
@@ -1,0 +1,60 @@
+---
+layout: full.html.hbs
+algolia: true
+title: deleteCredentials
+---
+
+# deleteCredentials
+
+{{{since "1.0.0"}}}
+
+
+Delete user credentials for the specified authentication strategy.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>
+Method: DELETE  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "deleteCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid) 
+* `strategy`: authentication strategy name to remove
+
+---
+
+## Response
+
+Return an acknowledgement.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "deleteCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": {
+    "acknowledged": true
+  }
+}
+```

--- a/src/api/1/controller-security/delete-profile/index.md
+++ b/src/api/1/controller-security/delete-profile/index.md
@@ -1,0 +1,65 @@
+---
+layout: full.html.hbs
+algolia: true
+title: deleteProfile
+---
+
+
+# deleteProfile
+
+{{{since "1.0.0"}}}
+
+Delete a security profile.
+
+An error is returned if the profile is still in use.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_profiles/<_id>[?refresh=wait_for]
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "deleteProfile",
+  "_id": "<profileId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: profile identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the profile deletion is indexed
+
+---
+
+## Response
+
+Return the deleted profile identifier.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<profileId>"
+  },
+  "action": "deleteProfile",
+  "controller": "security",
+  "requestId": "<unique request identifier>"
+}
+```
+

--- a/src/api/1/controller-security/delete-role/index.md
+++ b/src/api/1/controller-security/delete-role/index.md
@@ -1,0 +1,64 @@
+---
+layout: full.html.hbs
+algolia: true
+title: deleteRole
+---
+
+
+# deleteRole
+
+{{{since "1.0.0"}}}
+
+Delete a security role.
+
+An error is returned if the role is still in use.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/<_id>[?refresh=wait_for]
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "deleteRole",
+  "_id": "<roleId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: role identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the role deletion is indexed
+
+---
+
+## Response
+
+Return the deleted role identifier.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<roleId>"
+  }
+  "action": "deleteRole",
+  "controller": "security",
+  "requestId": "<unique request identifier>"
+}
+```

--- a/src/api/1/controller-security/delete-user/index.md
+++ b/src/api/1/controller-security/delete-user/index.md
@@ -1,0 +1,63 @@
+---
+layout: full.html.hbs
+algolia: true
+title: deleteUser
+---
+
+
+# deleteUser
+
+{{{since "1.0.0"}}}
+
+Delete a user and all their associate credentials.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>[?refresh=wait_for]
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "deleteUser",
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier) to delete
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the user deletion is indexed
+
+---
+
+## Response
+
+Return the deleted kuid.
+
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "result": {
+    "_id": "<kuid>",
+  }
+  "action": "deleteUser",
+  "controller": "security",
+  "requestId": "<unique request identifier>"
+}
+```

--- a/src/api/1/controller-security/get-all-credential-fields/index.md
+++ b/src/api/1/controller-security/get-all-credential-fields/index.md
@@ -1,0 +1,52 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getAllCredentialFields
+---
+
+
+# getAllCredentialFields
+
+{{{since "1.0.0"}}}
+
+Retrieve the list of fields accepted by authentication strategies.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/_fields
+Method: GET  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getAllCredentialFields"
+}
+```
+
+---
+
+## Response
+
+Return an object with a property per authentication strategy, pointing to an array of accepted field names.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getAllCredentialFields",
+  "controller": "security",
+  "result": {
+    "local": ["username", "password"],
+    "facebook": []
+  }
+}
+```
+

--- a/src/api/1/controller-security/get-credential-fields/index.md
+++ b/src/api/1/controller-security/get-credential-fields/index.md
@@ -1,0 +1,57 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getCredentialFields
+---
+
+
+# getCredentialFields
+
+{{{since "1.0.0"}}}
+
+Retrieve the list of accepted field names by the specified authenticaiton strategy.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/_fields
+Method: GET  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getCredentialFields",
+  "strategy": "<strategy>"
+}
+```
+
+---
+
+## Arguments
+
+* `strategy`: authentication strategy
+
+---
+
+## Response
+
+Return an array of accepted field names.
+
+### Example with the "local" authentication strategy:
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getCredentialFields",
+  "controller": "security",
+  "result": ["username", "password"]
+}
+```

--- a/src/api/1/controller-security/get-credentials-by-id/index.md
+++ b/src/api/1/controller-security/get-credentials-by-id/index.md
@@ -1,0 +1,66 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getCredentialsById
+---
+
+
+# getCredentialsById
+
+{{{since "1.0.0"}}}
+
+Get credential information for the user identified by the strategy's unique user identifier `userId`.
+
+The returned `result` object will vary depending on the strategy (see the [getById plugin function]({{ site_base_path }}plugins-reference/1/plugins-features/adding-authentication-strategy/#the-getbyid-function)), and it can be empty.
+
+**Note:** the user identifier to use depends on the specified strategy. If you wish to get credential information using a [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid) identifier, use the [getCredentials]({{ site_base_path }}api/1/controller-security/get-credentials/) API route instead.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>/_byId
+Method: GET  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getCredentialsById",
+  "strategy": "<strategy>",
+  "_id": "<userId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user credential identifier (this is NOT the kuid)
+* `strategy`: authentication strategy
+
+---
+
+## Response
+
+Return credentials information (depend on the authentication strategy).
+
+### Example with the "local" authentication strategy:
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "getCredentialsById",
+  "controller": "security",
+  "result": {
+    "username": "<userId>",
+    "kuid": "<kuid>"
+  }
+}
+```

--- a/src/api/1/controller-security/get-credentials/index.md
+++ b/src/api/1/controller-security/get-credentials/index.md
@@ -1,0 +1,66 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getCredentials
+---
+
+
+# getCredentials
+
+{{{since "1.0.0"}}}
+
+Get a user's credential information for the specified authentication strategy.
+
+The returned content depends on the authentication strategy, but it should never include sensitive information.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>
+Method: GET  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+* `strategy`: authentication strategy name
+
+---
+
+## Response
+
+Return credentials information (depend on the authentication strategy).
+
+### Example with the "local" authentication strategy:
+
+```javascript
+
+{
+  "status": 200,
+  "error": null,
+  "action": "getCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": {
+    "username": "MyUser",
+    "kuid": "<kuid>"
+  }
+}
+```

--- a/src/api/1/controller-security/get-profile-mapping/index.md
+++ b/src/api/1/controller-security/get-profile-mapping/index.md
@@ -1,0 +1,52 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getProfileMapping
+---
+
+# getProfileMapping
+
+{{{since "1.0.0"}}}
+
+Get the mapping of the internal security profiles collection.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_mapping
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getProfileMapping"
+}
+```
+
+---
+
+## Response
+
+Return the internal profiles mapping, using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "controller": "security",
+  "action": "getProfileMapping",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "mapping": {
+      // mapping
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/get-profile-rights/index.md
+++ b/src/api/1/controller-security/get-profile-rights/index.md
@@ -1,0 +1,82 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getProfileRights
+---
+
+
+# getProfileRights
+
+{{{since "1.0.0"}}}
+
+Get the detailed rights configured by a security profile.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_profiles/<_id>/_rights
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getProfileRights",
+  "_id": "<profileId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: profile identifier
+
+---
+
+## Response
+
+Return a `hits` array of objects. Each object is a security right described by the security profile:
+
+* `controller`: impacted Kuzzle controller
+* `action`: impacted controller action
+* `index`: data index
+* `collection`: data collection
+* `value`: tell if access is `allowed` or `denied`. If closures have been configured on the detailed scope, the value is `conditional`.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "result": {
+    // An array of objects containing the profile rights
+    "hits": [
+      {
+        "controller": "auth",
+        "action": "login",
+        "value": "allowed"
+      }, 
+      { 
+        "controller": "document",
+        "action": "get",
+        "index": "foo",
+        "collection": "bar",
+        "value": "allowed"
+      },
+      {
+        "controller": "document",
+        "action": "create",
+        "index": "foo",
+        "collection": "bar",
+        "value": "denied"
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-security/get-profile/index.md
+++ b/src/api/1/controller-security/get-profile/index.md
@@ -1,0 +1,83 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getProfile
+---
+
+
+# getProfile
+
+{{{since "1.0.0"}}}
+
+Get a security profile.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/<_id>
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getProfile",
+  "_id": "<profileId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: profile identifier
+
+---
+
+## Response
+
+Return the queried profile information:
+
+* `_id`: profile identifier
+* `_source`: profile content
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<profileId>",
+    "_source": {
+      "policies": [
+        {
+          "roleId": "<roleId>"
+        },
+        {
+          "roleId": "<roleId>",
+          "restrictedTo": [
+            {
+              "index": "<index>"
+            },
+            {
+              "index": "<index>",
+              "collections": [
+                "<coll1>",
+                "<coll2>"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "action": "getProfile",
+    "controller": "security",
+    "requestId": "<unique request identifier>"
+  }
+}
+```

--- a/src/api/1/controller-security/get-role-mapping/index.md
+++ b/src/api/1/controller-security/get-role-mapping/index.md
@@ -1,0 +1,53 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getRoleMapping
+---
+
+
+# getRoleMapping
+
+{{{since "1.0.0"}}}
+
+Get the mapping of the internal security roles collection.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/_mapping
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getRoleMapping"
+}
+```
+
+---
+
+## Response
+
+Return the internal profiles mapping, using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "controller": "security",
+  "action": "getRoleMapping",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "mapping": {
+      // ...
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/get-role/index.md
+++ b/src/api/1/controller-security/get-role/index.md
@@ -1,0 +1,67 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getRole
+---
+
+# getRole
+
+{{{since "1.0.0"}}}
+
+Get a security role.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/<_id>
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getRole",
+  "_id": "<roleId>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: role identifier
+
+---
+
+## Response
+
+Return the queried role:
+
+* `_id`: role identifier
+* `_source`: role description
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result": {
+    "_id": "<roleId>",
+    "_source": {
+      "controllers": {
+        "*": {
+          "actions": true
+        }
+      }
+    }
+  },
+  "action": "getRole",
+  "controller": "security",
+  "requestId": "<unique request identifier>"
+}
+```

--- a/src/api/1/controller-security/get-user-mapping/index.md
+++ b/src/api/1/controller-security/get-user-mapping/index.md
@@ -1,0 +1,52 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getUserMapping
+---
+
+# getUserMapping
+
+{{{since "1.0.0"}}}
+
+Get the mapping of the internal users collection.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/_mapping
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getUserMapping"
+}
+```
+
+---
+
+## Response
+
+Return the internal profiles mapping, using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html).
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "controller": "security",
+  "action": "getUserMapping",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "mapping": {
+      // ...
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/get-user-rights/index.md
+++ b/src/api/1/controller-security/get-user-rights/index.md
@@ -1,0 +1,80 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getUserRights
+---
+
+# getUserRights
+
+{{{since "1.0.0"}}}
+
+Get the detailed rights granted to a user.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>/_rights
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getUserRights",
+  "_id": "<kuid>"
+}
+```
+
+--- 
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+
+---
+
+## Response
+
+Return a `hits` array of objects. Each object is a security right granted or denied to the user:
+
+* `controller`: impacted Kuzzle controller
+* `action`: impacted controller action
+* `index`: data index
+* `collection`: data collection
+* `value`: tell if access is `allowed` or `denied`. If closures have been configured on the detailed scope, the value is `conditional`.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "result": {
+    "hits": [
+      {
+        "controller": "auth",
+        "action": "login",
+        "value": "allowed"
+      }, 
+      { 
+        "controller": "document",
+        "action": "get",
+        "index": "foo",
+        "collection": "bar",
+        "value": "allowed"
+      },
+      {
+        "controller": "document",
+        "action": "create",
+        "index": "foo",
+        "collection": "bar",
+        "value": "denied"
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-security/get-user/index.md
+++ b/src/api/1/controller-security/get-user/index.md
@@ -1,0 +1,63 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getUser
+---
+
+# getUser
+
+{{{since "1.0.0"}}}
+
+Get a user.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "getUser",
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+
+---
+
+## Response
+
+Return the user information:
+
+* `_id`: user kuid
+* `_source`: user description
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "security",
+  "action": "getUser",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",
+    "_source": {
+      "profileIds": ["<profileId>"]
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/has-credentials/index.md
+++ b/src/api/1/controller-security/has-credentials/index.md
@@ -1,0 +1,57 @@
+---
+layout: full.html.hbs
+algolia: true
+title: hasCredentials
+---
+
+# hasCredentials
+
+{{{since "1.0.0"}}}
+
+Check if a user has credentials registered for the specified authentication strategy.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>/_exists
+Method: GET  
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "hasCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>"
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier) 
+* `strategy`: authentication strategy
+
+---
+
+## Response
+
+Return a boolean telling whether the user can log in using the provided authentication strategy.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "hasCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": true
+}
+```

--- a/src/api/1/controller-security/index.md
+++ b/src/api/1/controller-security/index.md
@@ -1,0 +1,4 @@
+---
+layout: full.html.hbs
+title: security
+---

--- a/src/api/1/controller-security/m-delete-profiles/index.md
+++ b/src/api/1/controller-security/m-delete-profiles/index.md
@@ -1,0 +1,76 @@
+---
+layout: full.html.hbs
+algolia: true
+title: mDeleteProfiles
+---
+
+# mDeleteProfiles
+
+{{{since "1.0.0"}}}
+
+Delete multiple security profiles.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_mDelete[?refresh=wait_for]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "ids": ["profile1", "profile2", "..."]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "mDeleteProfiles",
+  "body": {
+    "ids": ["profile1", "profile2", "..."]
+  }
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletions are indexed
+
+---
+
+## Body properties
+
+* `ids`: an array of profile identifiers to delete
+
+---
+
+## Response
+
+Return an array of successfully deleted profiles.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "mDeleteProfiles",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": [
+    "profile1",
+    "profile2",
+    "..."
+  ]
+}
+```

--- a/src/api/1/controller-security/m-delete-roles/index.md
+++ b/src/api/1/controller-security/m-delete-roles/index.md
@@ -1,0 +1,76 @@
+---
+layout: full.html.hbs
+algolia: true
+title: mDeleteRoles
+---
+
+# mDeleteRoles
+
+{{{since "1.0.0"}}}
+
+Delete multiple security roles.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/_mDelete[?refresh=wait_for]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "ids": ["role1", "role2", "..."]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "mDeleteRoles",
+  "body": {
+    "ids": ["role1", "role2", "..."]
+  }
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletions are indexed
+
+---
+
+## Body properties
+
+* `ids`: an array of role identifiers to delete
+
+---
+
+## Response
+
+Return an array of successfully deleted roles.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "mDeleteRoles",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": [
+    "role1",
+    "role2",
+    "..."
+  ]
+}
+```

--- a/src/api/1/controller-security/m-delete-users/index.md
+++ b/src/api/1/controller-security/m-delete-users/index.md
@@ -1,0 +1,77 @@
+---
+layout: full.html.hbs
+algolia: true
+title: mDeleteUsers
+---
+
+# mDeleteUsers
+
+{{{since "1.0.0"}}}
+
+Delete multiple users.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/_mDelete[?refresh=wait_for]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "ids": ["kuid1", "kuid2", "..."]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "mDeleteUsers",
+  "body": {
+    "ids": ["kuid1", "kuid2", "..."]
+  }
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the deletions are indexed
+
+---
+
+## Body properties
+
+* `ids`: an array of user [kuids]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier) to delete
+
+---
+
+## Response
+
+Return an array of successfully deleted users.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "mDeleteUsers",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": [
+    "kuid1",
+    "kuid2", 
+    "..."
+   ]
+  }
+}
+```

--- a/src/api/1/controller-security/m-get-profiles/index.md
+++ b/src/api/1/controller-security/m-get-profiles/index.md
@@ -1,0 +1,82 @@
+---
+layout: full.html.hbs
+algolia: true
+title: mGetProfiles
+---
+
+# mGetProfiles
+
+{{{since "1.0.0"}}}
+
+Get multiple security profiles.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_mGet
+Method: POST  
+Body:
+```
+
+```js
+{
+  "ids": ["profile1", "profile2"]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "mGetProfiles",
+  "body": {
+    "ids": ["profile1", "profile2"]
+  }
+}
+```
+
+---
+
+## Body properties
+
+* `ids`: an array of profile identifiers to get
+
+---
+
+## Response
+
+Return a `hits` array of objects. Each object is a profile description, with the following properties:
+
+* `_id`: profile unique identifier
+* `_source`: profile description
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "mGetProfiles",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "profile1",
+        "_source": {
+          "policies": [{"roleId": "admin"}]
+        }
+      },
+      {
+        "_id": "profile2",
+        "_source": {
+          "policies": [{"roleId": "default"}]
+        }
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-security/m-get-roles/index.md
+++ b/src/api/1/controller-security/m-get-roles/index.md
@@ -1,0 +1,92 @@
+---
+layout: full.html.hbs
+algolia: true
+title: mGetRoles
+---
+
+# mGetRoles
+
+{{{since "1.0.0"}}}
+
+Get multiple security roles.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/_mGet
+Method: POST  
+Body:
+```
+
+```js
+{
+  "ids": ["role1", "role2"]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "mGetRoles",
+  "body": {
+    "ids": ["role1", "role2"]
+  }
+}
+```
+---
+
+## Body properties
+
+* `ids`: an array of role identifiers to get
+
+---
+
+## Response
+
+Return a `hits` array of objects. Each object is a role description, with the following properties:
+
+* `_id`: role unique identifier
+* `_source`: role description
+
+```javascript
+{
+  "status": 200,
+  "action": "mGetRoles",
+  "controller": "security",
+  "error": null,
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "role1",
+        "_source": {
+          "controllers": {
+            "*": {
+              "actions": true
+            }
+          }
+        }
+      },
+      {
+        "_id": "role2",
+        "_source": {
+          "controllers": {
+            "document": {
+              "actions": {
+                "get": true,
+                "search": true
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-security/replace-user/index.md
+++ b/src/api/1/controller-security/replace-user/index.md
@@ -1,0 +1,92 @@
+---
+layout: full.html.hbs
+algolia: true
+title: replaceUser
+---
+
+# replaceUser
+
+{{{since "1.0.0"}}}
+
+Replace a user with new configuration.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>/_replace[?refresh=wait_for]
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "profileIds": ["<profileId>"],
+  // additional user properties (optional)
+  "fullname": "John Doe"
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "replaceUser",
+  "_id": "<kuid>",
+  "body": {
+    "profileIds": ["<profileId>"],
+    // additional user properties (optional)
+    "fullname": "John Doe"
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the user replacement is indexed
+
+---
+
+## Body properties
+
+* `profileIds`: an array of security profiles attributed to the user
+
+### Optional:
+
+* any other property: additional user information
+
+---
+
+## Response
+
+Return the user replacement status:
+
+* `_id`: new user kuid
+* `_source`: new user content and attributed profiles
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "replaceUser",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",
+    "_source": {
+      "profileIds": ["<profileId>"],
+      "fullname": "John Doe"
+    }
+  }
+}
+```

--- a/src/api/1/controller-security/scroll-profiles/index.md
+++ b/src/api/1/controller-security/scroll-profiles/index.md
@@ -1,0 +1,89 @@
+---
+layout: full.html.hbs
+algolia: true
+title: scrollProfiles
+---
+
+# scrollProfiles
+
+{{{since "1.0.0"}}}
+
+This method moves a result set cursor forward, created by a [searchProfiles]({{ site_base_path }}api/1/controller-security/search-profiles) query with the `scroll` argument provided.
+
+The results that are returned from a `scrollProfiles` request reflect the state of the index at the time that the initial search request was made, like a snapshot in time. Subsequent changes to documents (index, update or delete) will only affect later search requests.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_scroll/<scrollId>[?scroll=<time to live>]
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "scrollProfiles",
+  "scrollId": "<scrollId>",
+  "scroll": "<time to live>"
+}
+```
+
+---
+
+## Arguments
+
+* `scrollId`: cursor unique identifier, obtained by either a searchProfiles or a scrollProfiles query
+
+### Optional:
+
+* `scroll`: refresh the cursor duration, using the [time to live](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#time-units) syntax.
+
+---
+
+## Response
+
+Return a paginated search result set, with the following properties:
+
+* `hits`: array of found profiles. Each document has the following properties:
+  * `_id`: profile unique identifier
+  * `_source`: profile definition
+* `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
+* `total`: total number of found profiles. Usually greater than the number of profiles in a result page
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "scrollProfiles",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "scrollId": "<new scroll id>",
+    "hits": [
+      {
+        "_id": "profile1",
+        "_source": {
+          "policies": [
+            // list of policies
+          ]
+        }
+      },
+      {
+        "_id": "profile2",
+        "_source": {
+          "policies": [
+            // list of policies
+          ]
+        }
+      }
+    ],
+    "total": 42
+  }
+}
+```

--- a/src/api/1/controller-security/scroll-users/index.md
+++ b/src/api/1/controller-security/scroll-users/index.md
@@ -1,0 +1,87 @@
+---
+layout: full.html.hbs
+algolia: true
+title: scrollUsers
+---
+
+# scrollUsers
+
+{{{since "1.0.0"}}}
+
+This method moves a result set cursor forward, created by a [searchUsers]({{ site_base_path }}api/1/controller-security/search-users) query with the `scroll` argument provided.
+
+The results that are returned from a `scrollUsers` request reflect the state of the index at the time that the initial search request was made, like a snapshot in time. Subsequent changes to documents (index, update or delete) will only affect later search requests.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/_scroll/<scrollId>[?scroll=<time to live>]
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "scrollUsers",
+  "scrollId": "<scrollId>",
+  "scroll": "<time to live>"
+}
+```
+
+---
+
+## Arguments
+
+* `scrollId`: cursor unique identifier, obtained by either a searchUsers or a scrollUsers query
+
+### Optional:
+
+* `scroll`: refresh the cursor duration, using the [time to live](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#time-units) syntax.
+
+---
+
+## Response
+
+Return a paginated search result set, with the following properties:
+
+* `hits`: array of found profiles. Each document has the following properties:
+  * `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+  * `_source`: user definition
+* `scrollId`: identifier to the next page of result. Can be different than the previous one(s)
+* `total`: total number of found users. Usually greater than the number of users in a result page
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "scrollUsers",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "scrollId": "<new scroll id>",
+    "hits": [
+      {
+        "_id": "kuid1",
+        "_source": { 
+          "profileIds": [{"roleId": "default"}],
+          "fullname": "John Doe"
+        }
+      },
+      {
+        "_id": "kuid2",
+        "_source": {
+          "profileIds": [{"roleId": "admin"}],
+          "fullname": "Beardy McBeardface"
+        }
+      }
+    ],
+    "total": 42
+  }
+}
+```

--- a/src/api/1/controller-security/search-profiles/index.md
+++ b/src/api/1/controller-security/search-profiles/index.md
@@ -1,0 +1,108 @@
+---
+layout: full.html.hbs
+algolia: true
+title: searchProfiles
+---
+
+# searchProfiles
+
+{{{since "1.0.0"}}}
+
+Search for security profiles, optionally returning only those linked to the provided list of security roles.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_search[?from=0][&size=42][&scroll=<time to live>]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "roles": [
+    "role1",
+    "admin"
+  ]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "searchProfiles",
+  "body": {
+    "roles": [
+      "role1",
+      "admin"
+    ]
+  },
+  // optional: result pagination configuration
+  "from": 0,
+  "size": 42,
+  "scroll": "<ttl>"
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `from`: the offset from the first result you want to fetch.  Usually used with the `size` argument
+* `scroll`: create a new forward-only result cursor. This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#time-units), at the end of which the cursor is destroyed. If set, a cursor identifier named `scrollId` will be returned in the results. This cursor can then be moved forward using the [scrollProfiles]({{ site_base_path }}api/1/controller-security/scroll-profiles) API action
+* `size`: the maximum number of profiles returned in one response page
+
+---
+
+## Body properties
+
+### Optional:
+
+* `roles`: an array of role identifiers. Restrict the search to profiles linked to the provided roles.
+
+---
+
+## Response
+
+Return an object with the following properties:
+
+* `hits`: array of object. Each object describes a found profile:
+  * `_id`: profile identifier
+  * `_source`: profile definition
+* `total`: total number of profiles found. Depending on pagination options, this can be greater than the actual number of profiles in a single result page
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "result":
+  {
+    "hits": [
+      {
+        "_id": "firstProfileId",
+        "_source": {
+          // Full profile definition
+        }
+      },
+      {
+        "_id": "secondProfileId",
+        "_source": {
+          // Full profile definition
+        }
+      }
+    ],
+    "total": 2
+  },
+  "action": "searchProfiles",
+  "controller": "security",
+  "requestId": "<unique request identifier>"
+}
+```

--- a/src/api/1/controller-security/search-roles/index.md
+++ b/src/api/1/controller-security/search-roles/index.md
@@ -1,0 +1,104 @@
+---
+layout: full.html.hbs
+algolia: true
+title: searchRoles
+---
+
+# searchRoles
+
+{{{since "1.0.0"}}}
+
+Search for security roles, optionally returning only those allowing access to the provided controllers.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/_search[?from=0][&size=42]
+Method: POST  
+Body:
+```
+
+```js
+{
+  // optional: retrieve only roles giving access to the
+  // provided controller names
+  "controllers": ["document", "security"]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "searchRoles",
+  "body": {
+    // optional: search for roles allowing access to the provided
+    // list of controllers
+    "controllers": ["document", "security"]
+  },
+  // optional: result pagination configuration
+  "from": 0,
+  "size": 42
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `from`: the offset from the first result you want to fetch.  Usually used with the `size` argument
+* `size`: the maximum number of profiles returned in one response page
+
+
+---
+
+## Body properties
+
+### Optional:
+
+* `controllers`: an array of controller names. Restrict the search to roles linked to the provided controllers.
+
+---
+
+## Response
+
+Return an object with the following properties:
+
+* `hits`: array of object. Each object describes a found role:
+  * `_id`: role identifier
+  * `_source`: role definition
+* `total`: total number of roles found. Depending on pagination options, this can be greater than the actual number of roles in a single result page
+
+```javascript
+{
+  "action": "searchRoles",
+  "controller": "security",
+  "error": null,
+  "requestId": "<unique request identifier>",
+  "result": 
+  {
+    "total": 1,
+    "hits": [
+      {
+        "_id": "<roleId>",
+        "_source": {
+          "controllers": {
+            "*": {
+              "actions": {
+                "*": true
+              }
+          }
+        }
+      }
+    ]
+  }
+  "status": 200
+}
+```

--- a/src/api/1/controller-security/search-users/index.md
+++ b/src/api/1/controller-security/search-users/index.md
@@ -1,0 +1,137 @@
+---
+layout: full.html.hbs
+algolia: true
+title: searchUsers
+---
+
+# searchUsers
+
+{{{since "1.0.0"}}}
+
+Search users.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/_search[?from=0][&size=42][&scroll=<time to live>]
+Method: POST  
+Body:
+```
+
+```js
+{
+  "bool": {
+    "must": [
+      {
+        "terms": {
+          "profileIds": ["anonymous", "default"]
+        }
+      },
+      {
+        "geo_distance": {
+          "distance": "10km",
+          "pos": {
+            "lat": 48.8566140,
+            "lon": 2.352222
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "searchUsers",
+  "body": {
+    "bool": {
+      "must": [
+        {
+          "in": {
+            "profileIds": ["anonymous", "default"]
+          }
+        },
+        {
+          "geo_distance": {
+            "distance": "10km",
+            "pos": {
+              "lat": "48.8566140",
+              "lon": "2.352222"
+            }
+          }
+        }
+      ]
+    }
+  },
+  // optional arguments
+  "from": 0,
+  "size": 10,
+  "scroll": "<time to live>"
+}
+```
+
+---
+
+## Arguments
+
+### Optional:
+
+* `from`: the offset from the first result you want to fetch.  Usually used with the `size` argument
+* `scroll`: create a new forward-only result cursor. This option must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/common-options.html#time-units), at the end of which the cursor is destroyed. If set, a cursor identifier named `scrollId` will be returned in the results. This cursor can then be moved forward using the [scrollUsers]({{ site_base_path }}api/1/controller-security/scroll-users) API action
+* `size`: the maximum number of users returned in one response page
+
+---
+
+## Body properties
+
+### Optional:
+
+The search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl.html) syntax.
+
+If the body is left empty, the result will return all available users.
+
+---
+
+## Response
+
+Return an object with the following properties:
+
+* `hits`: array of object. Each object describes a found user:
+  * `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+  * `_source`: user definition
+* `total`: total number of users found. Depending on pagination options, this can be greater than the actual number of users in a single result page
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "searchUsers",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "total": 2,
+    "hits": [
+      {
+        "_id": "kuid1",
+        "_source": {
+          // User content
+        }
+      },
+      {
+        "_id": "kuid2",
+        "_source" {
+          // User content
+        }
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-security/update-credentials/index.md
+++ b/src/api/1/controller-security/update-credentials/index.md
@@ -1,0 +1,80 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateCredentials
+---
+
+# updateCredentials
+
+{{{since "1.0.0"}}}
+
+Update a user credentials for the specified authentication strategy.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>/_update
+Method: PUT  
+Body:
+```
+
+```js
+{
+  // example with the "local" authentication strategy
+  "password": "<new password>"
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>",
+  "body": {
+    // example with the "local" authentication strategy
+    "password": "<new password>"
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier) 
+* `strategy`: authentication strategy
+
+---
+
+## Body properties
+
+The properties that can be sent to update a user credentials depend entirely of the authentication strategy. 
+
+---
+
+## Response
+
+Return the authentication strategy response.
+
+### Example for the "local" authentication strategy:
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "updateCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": {
+    "username": "MyUser",
+    "kuid": "<kuid>"
+  }
+}
+```

--- a/src/api/1/controller-security/update-profile-mapping/index.md
+++ b/src/api/1/controller-security/update-profile-mapping/index.md
@@ -1,0 +1,70 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateProfileMapping
+---
+
+# updateProfileMapping
+
+{{{since "1.0.0"}}}
+
+Update the internal profile storage mapping.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/_mapping
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "properties": {
+    // mapping
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateProfileMapping",
+  "body": {
+    "properties": {
+      // mapping
+    }
+  }
+}
+```
+
+---
+
+## Body properties
+
+* `properties`: mapping definition using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)
+
+---
+
+## Response
+
+Return an acknowledgement.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "updateProfileMapping",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "acknowledged": true
+  },
+}
+```

--- a/src/api/1/controller-security/update-profile/index.md
+++ b/src/api/1/controller-security/update-profile/index.md
@@ -1,0 +1,116 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateProfile
+---
+
+# updateProfile
+
+{{{since "1.0.0"}}}
+
+Update a security profile definition.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/profiles/<_id>/_update[?refresh=wait_for]
+Method: PUT  
+Body:
+```
+
+```js
+{
+    "policies": [
+      {
+        "roleId": "<roleId>"
+      },
+      {
+        "roleId": "<roleId>",
+        "restrictedTo": [
+          {
+            "index": "<index>"
+          },
+          {
+            "index": "<index>",
+            "collections": [
+              "<coll1>",
+              "<coll2>"
+            ]
+          }
+        ]
+      }
+    ]
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateProfile",
+  "_id": "<profileId>",
+  "body": {
+    "policies": [
+      {
+        "roleId": "<roleId>"
+      },
+      {
+        "roleId": "<roleId>",
+        "restrictedTo": [
+          {
+            "index": "<index>"
+          },
+          {
+            "index": "<index>",
+            "collections": [
+              "<coll1>",
+              "<coll2>"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: profile identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the profile changes are indexed
+
+---
+
+## Body properties
+
+* `policies`: [profile definition]({{site_base_path}}guide/1/essentials/security/#defining-profiles)
+
+---
+
+## Response
+
+Return the updated profile identifier and version number.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "updateProfile",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<profileId>",
+    "_version": 2
+  }
+}
+```

--- a/src/api/1/controller-security/update-role-mapping/index.md
+++ b/src/api/1/controller-security/update-role-mapping/index.md
@@ -1,0 +1,70 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateRoleMapping
+---
+
+# updateRoleMapping
+
+{{{since "1.0.0"}}}
+
+Update the internal role storage mapping.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/_mapping
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "properties": {
+    // mapping
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateRoleMapping",
+  "body": {
+    "properties": {
+      // mapping
+    }
+  }
+}
+```
+
+---
+
+## Body properties
+
+* `properties`: mapping definition using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)
+
+---
+
+## Response
+
+Return an acknowledgement.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "updateRoleMapping",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "acknowledged": true
+  },
+}
+```

--- a/src/api/1/controller-security/update-role/index.md
+++ b/src/api/1/controller-security/update-role/index.md
@@ -1,0 +1,92 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateRole
+---
+
+# updateRole
+
+{{{since "1.0.0"}}}
+
+Update a security role definition.
+
+**Note:** partial updates are not supported for roles, this API route will replace the entire role content with the provided one.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/roles/<_id>/_update[?refresh=wait_for]
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "controllers": {
+    "*": {
+      "actions": {
+        "*": true
+      }
+    }
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateRole",
+  "_id": "<roleId>",
+  "body": {
+    "controllers": {
+      "*": {
+        "actions": {
+          "*": true
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: role identifier
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the role changes are indexed
+
+---
+
+## Body properties
+
+* `controllers`: [role definition]({{ site_base_path }}guide/1/essentials/security/#defining-roles)
+
+---
+
+## Response
+
+Return the updated role identifier and version number.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "updateRole",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<roleId>",
+    "_version": 2
+  }
+}
+```

--- a/src/api/1/controller-security/update-user-mapping/index.md
+++ b/src/api/1/controller-security/update-user-mapping/index.md
@@ -1,0 +1,72 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateUserMapping
+---
+
+# updateUserMapping
+
+{{{since "1.0.0"}}}
+
+Update the internal user storage mapping.
+
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/_mapping
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "properties": {
+    // mapping
+  }
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateUserMapping",
+
+  "body": {
+    "properties": {
+      // mapping
+    }
+  }
+}
+```
+
+---
+
+## Body properties
+
+* `properties`: mapping definition using [Elasticsearch mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping.html)
+
+---
+
+## Response
+
+Return an acknowledgement.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "updateUserMapping",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "acknowledged": true
+  },
+}
+```

--- a/src/api/1/controller-security/update-user/index.md
+++ b/src/api/1/controller-security/update-user/index.md
@@ -1,0 +1,72 @@
+---
+layout: full.html.hbs
+algolia: true
+title: updateUser
+---
+
+# updateUser
+
+{{{since "1.0.0"}}}
+
+Update a user definition.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/users/<_id>/_update[?refresh=wait_for]
+Method: PUT  
+Body:
+```
+
+```js
+{
+  "fullname": "Walter Smith"
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "updateUser",
+  "_id": "<kuid>",
+  "body": {
+    "fullname": "Walter Smith"
+  }
+}
+```
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier)
+
+### Optional:
+
+* `refresh`: if set to `wait_for`, Kuzzle will not respond until the user changes are indexed
+
+
+---
+
+## Response
+
+Return the update user kuid and version number.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "updateUser",
+  "controller": "security",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<kuid>",
+    "_version": 2
+  }
+}
+```

--- a/src/api/1/controller-security/validate-credentials/index.md
+++ b/src/api/1/controller-security/validate-credentials/index.md
@@ -1,0 +1,77 @@
+---
+layout: full.html.hbs
+algolia: true
+title: validateCredentials
+---
+
+# validateCredentials
+
+{{{since "1.0.0"}}}
+
+Check if the provided credentials are well-formed. Does not actually save credentials.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/credentials/<strategy>/<_id>/_validate
+Method: POST  
+Body:
+```
+
+```js
+{
+  // example for the "local" authentication strategy
+  "username": "MyUser",
+  "password": "MyPassword"
+}
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "security",
+  "action": "validateCredentials",
+  "strategy": "<strategy>",
+  "_id": "<kuid>",
+  "body": {
+    // example for the "local" authentication strategy
+    "username": "MyUser",
+    "password": "MyPassword"
+  }
+}
+```
+
+---
+
+## Arguments
+
+* `_id`: user [kuid]({{site_base_path}}guide/1/kuzzle-depth/authentication/#the-kuzzle-user-identifier) 
+* `strategy`: authentication strategy
+
+---
+
+## Body properties
+
+The properties that can be sent to validate credentials depend entirely of the authentication strategy. 
+
+---
+
+## Response
+
+Return a boolean telling whether credentials are valid.
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "action": "validateCredentials",
+  "controller": "security",
+  "_id": "<kuid>",
+  "result": true
+}
+```


### PR DESCRIPTION
# Description

Migration of the security controller documentation into the new documentation system.

# How to test

See the netlify preview.

# New documentation format

The way controller actions are documented has been changed, and it now follows this template:

```
# <action name>

<"Added in vXX.YY.ZZ" tag>

<Action description>

---

## Query Syntax

### HTTP

<HTTP query documentation>

### Other protocols

<JSON query documentation>

---

[## Arguments (new section)]

<Required arguments documentation>

[### Optional:]

<Optional arguments documentation>

---

[## Body properties (new section)]

<Required body properties documentation>

[### Optional]

<Optional body properties documentation>

---

## Response

<Detailed response documentation, instead of having it embedded into response examples (new)>

<Response example, cleaned from unnecessary "documentation">
```

* `Arguments` and `Body properties` are separated sections because I found it easier to document that way, as otherwise we would need to explain every time that a "body" object can be added. 
* Action description is now reduced to the strict minimum, as lengthy explanations tend to make it less clear what the action does. Additional explanations often concern arguments that can be passed to the action, or about the response, so they have been moved in their corresponding sections
* Query syntax definition, and response examples have been simplified: explanatory comments have been moved outside the examples, and add as an exhaustive explanation instead.