### PR TITLE
API migration: server controller

### DIFF
--- a/src/api/1/controller-server/admin-exists/index.md
+++ b/src/api/1/controller-server/admin-exists/index.md
@@ -1,0 +1,52 @@
+---
+layout: full.html.hbs
+algolia: true
+title: adminExists
+---
+
+# adminExists
+
+{{{since "1.0.0"}}}
+
+Check that an administrator account exists.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_adminExists
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "adminExists"
+}
+```
+
+---
+
+## Response
+
+Return an `exists` boolean telling whether an administrator account exists.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "index": null,
+  "collection": null,
+  "action": "adminExists",
+  "controller": "server",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "exists": true
+  }
+}
+```

--- a/src/api/1/controller-server/admin-exists/index.md
+++ b/src/api/1/controller-server/admin-exists/index.md
@@ -8,7 +8,7 @@ title: adminExists
 
 {{{since "1.0.0"}}}
 
-Check that an administrator account exists.
+Checks that an administrator account exists.
 
 ---
 
@@ -34,7 +34,7 @@ Method: GET
 
 ## Response
 
-Return an `exists` boolean telling whether an administrator account exists.
+Returns an `exists` boolean telling whether an administrator account exists.
 
 ```javascript
 {

--- a/src/api/1/controller-server/get-all-stats/index.md
+++ b/src/api/1/controller-server/get-all-stats/index.md
@@ -1,0 +1,78 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getAllStats
+---
+
+# getAllStats
+
+{{{since "1.0.0"}}}
+
+Get all stored internal statistic snapshots.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_getAllStats
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "getAllStats"
+}
+```
+
+---
+
+## Response
+
+Return a statistic objects with the following properties:
+
+* `hits`: an array of statistic snapshots. By default, snapshots are made every 10 seconds and they are stored for 1 hour. Each snapshot is an object with the following properties:
+  * `completedRequests`: completed requests, per network protocol
+  * `connections`: number of active connections, per network protocol
+  * `failedRequests`: failed requests, per network protocol
+  * `ongoingRequests`: requests underway, per network protocol
+  * `timestamp`: snapshot timestamp, in Epoch-millis format
+* `total`: total number of available snapshots
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getAllStats",
+  "controller": "server",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "total": 1,
+    "hits": [
+      {
+        "completedRequests": {
+          "websocket": 148,
+          "http": 24,
+          "mqtt": 78
+        },
+        "failedRequests": {
+          "websocket": 3
+        },
+        "ongoingRequests": {
+          "mqtt": 8,
+          "http": 2
+        }
+        "connections": {
+          "websocket": 13
+        },
+        "timestamp": 1453110641308
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-server/get-all-stats/index.md
+++ b/src/api/1/controller-server/get-all-stats/index.md
@@ -8,7 +8,7 @@ title: getAllStats
 
 {{{since "1.0.0"}}}
 
-Get all stored internal statistic snapshots.
+Gets all stored internal statistic snapshots.
 
 ---
 
@@ -34,7 +34,7 @@ Method: GET
 
 ## Response
 
-Return a statistic objects with the following properties:
+Returns a statistic objects with the following properties:
 
 * `hits`: an array of statistic snapshots. By default, snapshots are made every 10 seconds and they are stored for 1 hour. Each snapshot is an object with the following properties:
   * `completedRequests`: completed requests, per network protocol

--- a/src/api/1/controller-server/get-config/index.md
+++ b/src/api/1/controller-server/get-config/index.md
@@ -8,7 +8,7 @@ title: getConfig
 
 {{{since "1.0.0"}}}
 
-Return the current Kuzzle configuration.
+Returns the current Kuzzle configuration.
 
 This route should only be accessible to administrators, as it might return sensitive information about the backend.
 
@@ -36,7 +36,7 @@ Method: GET
 
 ## Response
 
-Return the complete Kuzzle configuration, in JSON format.
+Returns the complete Kuzzle configuration, in JSON format.
 
 ```javascript
 {

--- a/src/api/1/controller-server/get-config/index.md
+++ b/src/api/1/controller-server/get-config/index.md
@@ -1,0 +1,71 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getConfig
+---
+
+# getConfig
+
+{{{since "1.0.0"}}}
+
+Return the current Kuzzle configuration.
+
+This route should only be accessible to administrators, as it might return sensitive information about the backend.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_getConfig
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "getConfig"
+}
+```
+
+---
+
+## Response
+
+Return the complete Kuzzle configuration, in JSON format.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getConfig",
+  "controller": "server",
+  "result": {
+    "limits": {
+      "concurrentRequests": 100,
+      "documentsFetchCount": 10000,
+      "documentsWriteCount": 200,
+      "requestsBufferSize": 50000,
+      "requestsBufferWarningThreshold": 5000,
+      "subscriptionConditionsCount": 16,
+      "subscriptionMinterms": 0,
+      "subscriptionRooms": 1000000,
+      "subscriptionDocumentTTL": 259200
+    },
+    "plugins": {
+      "common": {
+        "bootstrapLockTimeout": 5000,
+        "pipeWarnTime": 500,
+        "pipeTimeout": 5000,
+        "initTimeout": 10000
+      }
+    },
+    // ... etc ...
+    "version": "1.5.1"
+  }
+}
+```

--- a/src/api/1/controller-server/get-last-stats/index.md
+++ b/src/api/1/controller-server/get-last-stats/index.md
@@ -8,7 +8,7 @@ title: getLastStats
 
 {{{since "1.0.0"}}}
 
-Return the most recent statistics snapshot.
+Returns the most recent statistics snapshot.
 
 ---
 
@@ -34,7 +34,7 @@ Method: GET
 
 ## Response
 
-Return the last statistic snapshot, with the following properties:
+Returns the last statistic snapshot, with the following properties:
 
 * `completedRequests`: completed requests, per network protocol
 * `connections`: number of active connections, per network protocol

--- a/src/api/1/controller-server/get-last-stats/index.md
+++ b/src/api/1/controller-server/get-last-stats/index.md
@@ -1,0 +1,71 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getLastStats
+---
+
+# getLastStats
+
+{{{since "1.0.0"}}}
+
+Return the most recent statistics snapshot.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_getLastStats
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "getLastStats"
+}
+```
+
+---
+
+## Response
+
+Return the last statistic snapshot, with the following properties:
+
+* `completedRequests`: completed requests, per network protocol
+* `connections`: number of active connections, per network protocol
+* `failedRequests`: failed requests, per network protocol
+* `ongoingRequests`: requests underway, per network protocol
+* `timestamp`: snapshot timestamp, in Epoch-millis format
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getLastStats",
+  "controller": "server",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "completedRequests": {
+      "websocket": 148,
+      "http": 24,
+      "mqtt": 78
+    },
+    "failedRequests": {
+      "websocket": 3
+    },
+    "ongoingRequests": {
+      "mqtt": 8,
+      "http": 2
+    }
+    "connections": {
+      "websocket": 13
+    },
+    "timestamp": 1453110641308
+  }
+}
+```

--- a/src/api/1/controller-server/get-stats/index.md
+++ b/src/api/1/controller-server/get-stats/index.md
@@ -8,7 +8,7 @@ title: getStats
 
 {{{since "1.0.0"}}}
 
-Return statistics snapshots within a provided timestamp range.
+Returns statistics snapshots within a provided timestamp range.
 
 ---
 
@@ -36,7 +36,7 @@ Method: GET
 
 ## Response
 
-Return the found statistic snapshots in the following format:
+Returns the found statistic snapshots in the following format:
 
 * `hits`: array of statistic snapshots. By default, snapshots are made every 10 seconds and they are stored for 1 hour. Each snapshot is an object with the following properties:
   * `completedRequests`: completed requests, per network protocol

--- a/src/api/1/controller-server/get-stats/index.md
+++ b/src/api/1/controller-server/get-stats/index.md
@@ -1,0 +1,80 @@
+---
+layout: full.html.hbs
+algolia: true
+title: getStats
+---
+
+# getStats
+
+{{{since "1.0.0"}}}
+
+Return statistics snapshots within a provided timestamp range.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_getStats[?startTime=<Epoch-millis>][&stopTime=<Epoch-millis>]
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "getStats",
+  "startTime": <timestamp>,
+  "stopTime": <timestamp>
+}
+```
+
+---
+
+## Response
+
+Return the found statistic snapshots in the following format:
+
+* `hits`: array of statistic snapshots. By default, snapshots are made every 10 seconds and they are stored for 1 hour. Each snapshot is an object with the following properties:
+  * `completedRequests`: completed requests, per network protocol
+  * `connections`: number of active connections, per network protocol
+  * `failedRequests`: failed requests, per network protocol
+  * `ongoingRequests`: requests underway, per network protocol
+  * `timestamp`: snapshot timestamp, in Epoch-millis format
+* `total`: total number of available snapshots
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "action": "getStats",
+  "controller": "server",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "total": 1,
+    "hits": [
+      {
+        "completedRequests": {
+          "websocket": 148,
+          "http": 24,
+          "mqtt": 78
+        },
+        "failedRequests": {
+          "websocket": 3
+        },
+        "ongoingRequests": {
+          "mqtt": 8,
+          "http": 2
+        }
+        "connections": {
+          "websocket": 13
+        },
+        "timestamp": 1453110641308
+      }
+    ]
+  }
+}
+```

--- a/src/api/1/controller-server/index.md
+++ b/src/api/1/controller-server/index.md
@@ -1,0 +1,4 @@
+---
+layout: full.html.hbs
+title: server
+---

--- a/src/api/1/controller-server/info/index.md
+++ b/src/api/1/controller-server/info/index.md
@@ -1,0 +1,110 @@
+---
+layout: full.html.hbs
+algolia: true
+title: info
+---
+
+# info
+
+{{{since "1.0.0"}}}
+
+Return information about Kuzzle: available API (base + extended), plugins, external services (Redis, Elasticsearch, ...), servers, etc.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512
+URL(2): http://kuzzle:7512/_serverInfo
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "info"
+}
+```
+
+---
+
+## Response
+
+Return a serverInfo object with the following properties:
+
+* `kuzzle`: kuzzle information about its API, active plugins, and system information
+* `services`: description and status of external services (e.g. Redis, Elasticsearch, ...)
+
+```javascript
+{
+  "status": 200,
+  "error": null,
+  "controller": "server",
+  "action": "info",
+  "result": {
+    "serverInfo": {
+      "kuzzle": {
+        "api": {
+          "routes": {
+            // complete exposed API documentation
+            // example:
+            "auth": {
+              "login": {
+                "controller": "auth",
+                "action": "login",
+                "http": [
+                    {
+                        "url": "/_login/:strategy",
+                        "verb": "GET"
+                    },
+                    {
+                        "url": "/_login/:strategy",
+                        "verb": "POST"
+                    }
+                ]
+              }
+            }
+          }
+        },
+        "memoryUsed": 115036160,
+        "nodeVersion": "v8.9.0",
+        "plugins": {
+          // plugins information
+          // example:
+          "kuzzle-plugin-auth-passport-local": {
+            "manifest": {
+              "name": "kuzzle-plugin-auth-passport-local",
+              "path": "/var/app/plugins/enabled/kuzzle-plugin-auth-passport-local",
+              "kuzzleVersion": ">=1.0.0 <2.0.0"
+            },
+            "hooks": [],
+            "pipes": [],
+            "controllers": [],
+            "routes": [],
+            "strategies": [ "local" ]
+          }
+        },
+        "system": {
+          "cpus": [
+            // list of CPUs
+          ],
+          "memory": {
+            "total": 16420540416,
+            "free": 1214001152
+          },
+        },
+        "uptime": "98436.853s",
+        "version": "<kuzzle version>"
+      },
+      "services": {
+        // external services list, description and status
+      }
+    }
+  }
+}
+```

--- a/src/api/1/controller-server/info/index.md
+++ b/src/api/1/controller-server/info/index.md
@@ -8,7 +8,7 @@ title: info
 
 {{{since "1.0.0"}}}
 
-Return information about Kuzzle: available API (base + extended), plugins, external services (Redis, Elasticsearch, ...), servers, etc.
+Returns information about Kuzzle: available API (base + extended), plugins, external services (Redis, Elasticsearch, ...), servers, etc.
 
 ---
 
@@ -35,7 +35,7 @@ Method: GET
 
 ## Response
 
-Return a serverInfo object with the following properties:
+Returns a serverInfo object with the following properties:
 
 * `kuzzle`: kuzzle information about its API, active plugins, and system information
 * `services`: description and status of external services (e.g. Redis, Elasticsearch, ...)

--- a/src/api/1/controller-server/now/index.md
+++ b/src/api/1/controller-server/now/index.md
@@ -8,7 +8,7 @@ title: now
 
 {{{since "1.0.0"}}}
 
-Return the current server timestamp, in Epoch-millis format.
+Returns the current server timestamp, in Epoch-millis format.
 
 ---
 
@@ -34,7 +34,7 @@ Method: GET
 
 ## Response
 
-Return a `now` property containing the server timestamp, in Epoch-millis format.
+Returns a `now` property containing the server timestamp, in Epoch-millis format.
 
 ```javascript
 {

--- a/src/api/1/controller-server/now/index.md
+++ b/src/api/1/controller-server/now/index.md
@@ -1,0 +1,50 @@
+---
+layout: full.html.hbs
+algolia: true
+title: now
+---
+
+# now
+
+{{{since "1.0.0"}}}
+
+Return the current server timestamp, in Epoch-millis format.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_now
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "server",
+  "action": "now"
+}
+```
+
+---
+
+## Response
+
+Return a `now` property containing the server timestamp, in Epoch-millis format.
+
+```javascript
+{
+  "status": 200,                     
+  "error": null,                     
+  "controller": "server",
+  "action": "now",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "now": 1447151167622
+  }
+}
+```


### PR DESCRIPTION
# Description

Migration of the server controller documentation into the new documentation system.

# How to test

See the netlify preview.

# New documentation format

The way controller actions are documented has been changed, and it now follows this template:

```
# <action name>

<"Added in vXX.YY.ZZ" tag>

<Action description>

---

## Query Syntax

### HTTP

<HTTP query documentation>

### Other protocols

<JSON query documentation>

---

[## Arguments (new section)]

<Required arguments documentation>

[### Optional:]

<Optional arguments documentation>

---

[## Body properties (new section)]

<Required body properties documentation>

[### Optional]

<Optional body properties documentation>

---

## Response

<Detailed response documentation, instead of having it embedded into response examples (new)>

<Response example, cleaned from unnecessary "documentation">
```

* `Arguments` and `Body properties` are separated sections because I found it easier to document that way, as otherwise we would need to explain every time that a "body" object can be added. 
* Action description is now reduced to the strict minimum, as lengthy explanations tend to make it less clear what the action does. Additional explanations often concern arguments that can be passed to the action, or about the response, so they have been moved in their corresponding sections
* Query syntax definition, and response examples have been simplified: explanatory comments have been moved outside the examples, and add as an exhaustive explanation instead.