### PR TITLE
Change inline-blockquotes style to a more lighter one

### DIFF
--- a/src/assets/stylesheets/_config.scss
+++ b/src/assets/stylesheets/_config.scss
@@ -73,4 +73,4 @@ $md-code-color: #282c34;
 $md-keyboard-background: #fcfcfc;
 $md-keyboard-color: #555555;
 
-$md-code-background-inline: #757575;
+$md-code-background-inline: rgba(27,31,35,0.1);

--- a/src/assets/stylesheets/base/_typeset.scss
+++ b/src/assets/stylesheets/base/_typeset.scss
@@ -143,7 +143,6 @@ kbd {
   pre {
     font-family: 'Roboto Mono', 'Courier New', Courier, monospace;
     background-color: $md-code-background;
-    color: $md-code-color;
     font-size: 1.45rem;
     direction: ltr;
     color: white;
@@ -152,19 +151,19 @@ kbd {
       white-space: pre-wrap;
     }
   }
-
+  
+  pre > code {
+    color: white
+  }
+  
   // Inline code blocks, correct relative ems for smaller font size
   code {
     $correct: 1 / 0.85;
-
+    padding: 3px;
     margin: 0 0.25em * $correct;
-    padding: 0.0625em * $correct 0;
     border-radius: 0.2rem;
-    box-shadow: +0.25em * $correct 0 0 $md-code-background-inline,
-      -0.25em * $correct 0 0 $md-code-background-inline;
-    box-decoration-break: clone;
     background-color: $md-code-background-inline;
-
+    color: black;
     // Remove box-shadows for print
     @media print {
       box-shadow: none;


### PR DESCRIPTION
## What does this PR do?
Just a tiny litle enhancement ! As discussed with the team, we wanted inline-blockquotes style to be more lighter.

Before : 
![blockqoutes_before](https://user-images.githubusercontent.com/3192870/46792502-cff14a80-cd43-11e8-81fb-972c6aeb16f8.png)

And now : 
![blockquotes_after](https://user-images.githubusercontent.com/3192870/46792589-029b4300-cd44-11e8-9e58-549ae15d1ecf.png)

### How should this be manually tested?
