### PR TITLE
Fix dead link for sdk js 5 and make sdk js 6 default sdk

### DIFF
--- a/src/sdk-reference/index.md
+++ b/src/sdk-reference/index.md
@@ -14,7 +14,7 @@ but we’re working on extending the support to many more.
 
 <br>
 <div class="Languages">
-  <a href="/sdk-reference/js/5/essentials/" class="Languages-item">
+  <a href="/sdk-reference/js/6/essentials/" class="Languages-item">
     <img src="/assets/images/logos/javascript.svg" alt="js logo" class="Languages-item-logo">
     <div class="Languages-item-name">Javascript</div>
   </a>

--- a/src/sdk-reference/js/5/essentials/index.md
+++ b/src/sdk-reference/js/5/essentials/index.md
@@ -1,0 +1,9 @@
+---
+layout: sdk.html.hbs
+algolia: true
+title: Essentials
+description: Kuzzle SDKs basic concepts
+order: 0
+---
+
+*Work in progress, use the selector on the right to see an other SDK*


### PR DESCRIPTION

## What does this PR do?

Everything in the title

