### PR TITLE
API Query Syntax documentation

### DIFF
--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -16,7 +16,7 @@ Except for HTTP, Kuzzle expects the exact same query format for all communicatio
 
 HTTP queries are split into the four HTTP usual parts: URL, verb, headers and body.
 
-Every API routes documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol. 
+Every API route documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol. 
 
 ### Optional headers
 
@@ -31,10 +31,11 @@ The following list of HTTP headers can be added to any and all HTTP requests:
 Body contents can be sent in the following formats:
 
 * `application/json`: raw JSON
-* `multipart/form-data`: HTML forms; both key-value pairs and files can be sent that way. There is currently no native API route supporting file contents in queries, but plugins can freely use that feature
+* `multipart/form-data`: HTML forms; both field-value pairs and field-files pairs can be sent that way. There is currently no native API route supporting file contents in queries, but plugins can freely use that feature
 
 If a HTML form is sent that way, the resulting body content will be translated into a JSON object, with as many keys as the provided form fields.  
 If the form field holds a file, then the corresponding JSON key will refer to an object instead of a mere value, with the following properties:
+
   * `filename`: file's name
   * `encoding`: file encoding
   * `mimetype`: MIME type
@@ -82,9 +83,9 @@ Depending on the API route executed, other parameters may be required. Those are
 There are 2 parameters that can be provided to all queries, independently to the API route executed:
 
 * `jwt`: user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
-* `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their corresponding query
+* `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their  query of origin
 
-Apart from these two, a few other parameters are very commonly found in API queries:
+Additionally, a few other parameters are very commonly found in API queries:
 
 * `_id`: unique identifier (e.g. document ID, user kuid, memory storage key, ...)
 * `body`: query content (e.g. document content, message content, mappings, ...)

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -45,7 +45,7 @@ If the form field holds a file, then the corresponding JSON key will refer to an
 
 ## Other protocols
 
-<div class="alert alert-info">Kuzzle's extensible protocol system allows communication in virtually any format. This documentation section describes the format that must be used to pass queries to Kuzzle itself, either directly by users (for instance, our <code>MQTT</code> protocol), or indirectly, translated by the custom protocol layer.</div>
+<div class="alert alert-info">Kuzzle's extensible protocol system allows communication in virtually any format. This documentation section describes the format that must be used to pass queries to Kuzzle itself, either directly by users (for instance, our <a href="https://github.com/kuzzleio/protocol-mqtt">MQTT protocol</a>), or indirectly, translated by the custom protocol layer.</div>
 
 Queries made to Kuzzle must be encoded using JSON, and have the following format:
 

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -33,6 +33,13 @@ Body contents can be sent in the following formats:
 * `application/json`: raw JSON
 * `multipart/form-data`: HTML forms; both key-value pairs and files can be sent that way. There is currently no native API route supporting file contents in queries, but plugins can freely use that feature
 
+If a HTML form is sent that way, the resulting body content will be translated into a JSON object, with as many keys as the provided form fields.  
+If the form field holds a file, then the corresponding JSON key will refer to an object instead of a mere value, with the following properties:
+  * `filename`: file's name
+  * `encoding`: file encoding
+  * `mimetype`: MIME type
+  * `file`: file content, encoded in base64
+
 ---
 
 ## Other protocols

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -84,6 +84,7 @@ There are 2 parameters that can be provided to all queries, independently to the
 
 * `jwt`: user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
 * `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their  query of origin
+* `volatile`: user-defined data, without any impact to the query. Use that object to pass information about the query itself to real-time subscribers. Read more [here]({{site_base_path}}/api/1/volatile-data)
 
 Additionally, a few other parameters are very commonly found in API queries:
 

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -84,7 +84,7 @@ There are 3 parameters that can be provided to all queries, independently to the
 
 * `jwt`: user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
 * `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their  query of origin
-* `volatile`: user-defined data, without any impact to the query. Use that object to pass information about the query itself to real-time subscribers. Read more [here]({{site_base_path}}/api/1/volatile-data)
+* `volatile`: user-defined data, without any impact to the query. Use that object to pass information about the query itself to real-time subscribers. Read more [here]({{ site_base_path }}/api/1/volatile-data)
 
 Additionally, a few other parameters are very commonly found in API queries:
 

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -1,0 +1,81 @@
+---
+layout: full.html.hbs
+algolia: true
+title: Query Syntax
+description: Kuzzle query format
+order: 200
+---
+
+# Query Syntax
+
+Except for HTTP, Kuzzle expects the exact same query format for all communication protocols.
+
+---
+
+## HTTP
+
+HTTP queries are split into the four HTTP usual parts: URL, verb, headers and body.
+
+Every API routes documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol.
+
+Additionally to the specific HTTP documentation, the following list of HTTP headers can be added to any and all HTTP requests:
+
+* `Accept-Encoding`: compression algorithm(s) usable by Kuzzle to encode the query response. Accepted encodings, in order of preference: `gzip`, `deflate`, `identity`. 
+* `Authorization` (expected value: `Bearer <token>`): user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
+* `Content-Encoding`: compression algorithm(s) used to encode the body sent to Kuzzle. Accepted encodings: `deflate`, `gzip`, `identity`
+
+---
+
+## Other protocols
+
+<div class="alert alert-info">Kuzzle's extensible protocol system allows communication in virtually any format. This documentation section describes the format that must be used to pass queries to Kuzzle itself, either directly by users (for instance, our <code>MQTT</code> protocol), or indirectly, translated by the custom protocol layer.</div>
+
+Queries made to Kuzzle must be encoded using JSON, and have the following format:
+
+```javascript
+{
+  // required by all queries
+  "controller": "<controller>",
+  "action": "<action>",
+
+  // optional, can be added to all queries
+  "requestId": "<unique request identifier>",
+  "jwt": "<token>",
+
+  // commonly found parameters
+  "index": "<index>",
+  "collection": "<collection>",
+  "body": {
+    // query content
+  },
+  "_id": "<unique ID>"
+}
+```
+
+### Required parameters:
+
+The following 2 parameters are required by all API requests, as these are directly used by Kuzzle to redirect the query to the correct API action:
+
+* `controller`: accessed Kuzzle API controller 
+* `action`: API controller action to be executed
+
+Depending on the API route executed, other parameters may be required. Those are detailed in the corresponding API sections.
+
+### Commonly found parameters:
+
+There are 2 parameters that can be provided to all queries, independently to the API route executed:
+
+* `jwt`: user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
+* `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their corresponding query
+
+Apart from these two, a few other parameters are very commonly found in API queries:
+
+* `_id`: unique identifier (e.g. document ID, user kuid, memory storage key, ...)
+* `body`: query content (e.g. document content, message content, mappings, ...)
+* `collection`: data collection
+* `index`: data index
+
+### Other parameters
+
+Kuzzle does not enforce a fixed list of parameters. Rather, API actions freely design the parameters list they need, and Kuzzle internal structures reflect that freedom.  
+This principle is especially useful, as it allows plugins to set their own list of required and optional parameters, without constraint.

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -80,7 +80,7 @@ Depending on the API route executed, other parameters may be required. Those are
 
 ### Commonly found parameters:
 
-There are 2 parameters that can be provided to all queries, independently to the API route executed:
+There are 3 parameters that can be provided to all queries, independently to the API route executed:
 
 * `jwt`: user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
 * `requestId`: user-defined request identifier. Kuzzle does not guarantee that responses are sent back in the same order than queries are made; use that field to link responses to their  query of origin

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -16,7 +16,7 @@ Except for HTTP, Kuzzle expects the exact same query format for all communicatio
 
 HTTP queries are split into the four HTTP usual parts: URL, verb, headers and body.
 
-Every API route documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol. 
+Every API route documentation has a dedicated HTTP section, explaining how to use that route with the HTTP protocol. 
 
 ### Optional headers
 
@@ -31,7 +31,7 @@ The following list of HTTP headers can be added to any and all HTTP requests:
 Body contents can be sent in the following formats:
 
 * `application/json`: raw JSON
-* `multipart/form-data`: HTML forms; both field-value pairs and field-files pairs can be sent that way. There is currently no native API route supporting file contents in queries, but plugins can freely use that feature
+* `multipart/form-data`: HTML forms; both field-value pairs and field-files pairs can be sent that way
 
 If a HTML form is sent that way, the resulting body content will be translated into a JSON object, with as many keys as the provided form fields.  
 If the form field holds a file, then the corresponding JSON key will refer to an object instead of a mere value, with the following properties:

--- a/src/api/1/query-syntax/index.md
+++ b/src/api/1/query-syntax/index.md
@@ -16,13 +16,22 @@ Except for HTTP, Kuzzle expects the exact same query format for all communicatio
 
 HTTP queries are split into the four HTTP usual parts: URL, verb, headers and body.
 
-Every API routes documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol.
+Every API routes documentation has a dedicated HTTP section, explaining how to use that route using the HTTP protocol. 
 
-Additionally to the specific HTTP documentation, the following list of HTTP headers can be added to any and all HTTP requests:
+### Optional headers
+
+The following list of HTTP headers can be added to any and all HTTP requests:
 
 * `Accept-Encoding`: compression algorithm(s) usable by Kuzzle to encode the query response. Accepted encodings, in order of preference: `gzip`, `deflate`, `identity`. 
 * `Authorization` (expected value: `Bearer <token>`): user's authentification token, obtained through the [login]({{ site_base_path }}api/1/controller-aut/login) method
 * `Content-Encoding`: compression algorithm(s) used to encode the body sent to Kuzzle. Accepted encodings: `deflate`, `gzip`, `identity`
+
+### Body encoding
+
+Body contents can be sent in the following formats:
+
+* `application/json`: raw JSON
+* `multipart/form-data`: HTML forms; both key-value pairs and files can be sent that way. There is currently no native API route supporting file contents in queries, but plugins can freely use that feature
 
 ---
 


### PR DESCRIPTION
# Description

Complete rewrite of the following documentation section: https://docs.kuzzle.io/api-documentation/query-syntax/

Expected improvements:
* HTTP:
  * optional headers are now documented 
  * content type `multipart/form-data` is now fully documented
* Other protocols:
  * define what "other protocols" are
  * document the universally required `controller` and `action` parameters
  * document the universally optional `jwt`, `requestId` and `volatile` parameters
 
Overall, I expect this new documentation to be clearer than our current one.
