### PR TITLE
Tests stack: add a ulimit configuration to match ES prereqs

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -22,6 +22,8 @@ services:
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1
+    ulimits:
+      nofile: 65536
     environment:
       - cluster.name=kuzzle
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
Without this configuration, ES fails to start on servers with stricter limits (ES is part of the Kuzzle stack needed to test code examples).