### PR TITLE
[sdk/js/6] fix "collection.searchSpecifications" test template

### DIFF
--- a/src/sdk-reference/js/6/collection/search-specifications/snippets/search-specifications.js
+++ b/src/sdk-reference/js/6/collection/search-specifications/snippets/search-specifications.js
@@ -14,7 +14,7 @@ try {
   };
 
   const searchResult = await kuzzle.collection.searchSpecifications(body, options);
-  console.log(searchResult.response);
+  console.log(searchResult);
   /*
   {
     "total": 1,
@@ -42,7 +42,7 @@ try {
     "scrollId": "DnF1ZXJ5VGhlbkZldGNoBQAAAAAAAACSFlgtZTJFYjNiU1FxQzhSNUFpNlZHZGcAAAAAAAAAkxZYLWUyRWIzYlNRcUM4UjVBaTZWR2RnAAAAAAAAAJQWWC1lMkViM2JTUXFDOFI1QWk2VkdkZwAAAAAAAACVFlgtZTJFYjNiU1FxQzhSNUFpNlZHZGcAAAAAAAAAlhZYLWUyRWIzYlNRcUM4UjVBaTZWR2Rn"
   }
   */
-  if (searchResult.response.hits[0]._source.validation.fields.license.type === 'string') {
+  if (searchResult.hits[0]._source.validation.fields.license.type === 'string') {
     console.log('Success');
   }
 } catch (error) {


### PR DESCRIPTION
Fix the failing test on collection.searchSpecifications because now the results are stored in a SearchResult object, instead of being directly returned (at least that's what I inferred from the code I read)