### PR TITLE
KZL-738 Set middle content column margin to fit 80 chars in code blocks

### DIFF
--- a/src/assets/stylesheets/layout/_content.scss
+++ b/src/assets/stylesheets/layout/_content.scss
@@ -32,8 +32,8 @@
 
     // [screen +]: Increase horizontal spacing
     @include break-from-device(screen) {
-      margin-right: 2.4rem;
-      margin-left: 2.4rem;
+      margin-right: 0;
+      margin-left: 0;
     }
 
     // Hack: add pseudo element for spacing, as the overflow of the content

--- a/src/assets/stylesheets/layout/_search.scss
+++ b/src/assets/stylesheets/layout/_search.scss
@@ -11,6 +11,9 @@ $md-toggle__search--checked: '[data-md-toggle="search"]:checked ~ .md-header';
 
 // Search container
 .md-search {
+  position: relative;
+  left: 1.4rem;
+  
   // Hide search, if JavaScript is not available.
   .no-js & {
     display: none;

--- a/src/assets/stylesheets/layout/_sidebar.scss
+++ b/src/assets/stylesheets/layout/_sidebar.scss
@@ -12,7 +12,7 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
 // Sidebar container
 .md-sidebar {
   position: absolute;
-  width: 24.2rem;
+  width: 23.2rem;
   padding: 2.4rem 0;
   overflow: hidden;
   
@@ -103,6 +103,10 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
         margin-right: 122rem;
         margin-left: initial;
       }
+    }
+    
+    .md-sidebar__inner {
+      overflow-x: hidden;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?
Set middle content column margin and reduce little bit sidebar width to fit 80 chars in code blocks

### How should this be manually tested?
https://deploy-preview-96--kuzzle-doc-v2.netlify.com/sdk-reference/js/6/auth/check-token/

Check the signature, there is no more horizontal scrollbar.

### Other changes
Add css overflow rules to the right menu to disable horizontal scrolling
