### PR TITLE
[ci] Use script provider for s3 sync --delete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,13 +168,9 @@ jobs:
         - npm run build
 
       deploy:
-        provider: s3
-        access_key_id: $AWS_ACCESS_KEY_ID
-        secret_access_key: $AWS_SECRET_ACCESS_KEY
-        bucket: $AWS_S3_BUCKET
-        region: us-west-2
+        provider: script
+        script: ~/.local/bin/aws s3 sync build s3://$AWS_S3_BUCKET --delete
         skip_cleanup: true
-        local-dir: build
         on:
           branch: master
 


### PR DESCRIPTION
## What does this PR do?
Use Travis `script` provider instead of `s3` to allow to `--delete` on deployments

### How should this be manually tested?
You can only check `.travis.yml` syntax