### PR TITLE
[dev] do not try to push to s3 on dev

### DIFF
--- a/run-snippet-tests.sh
+++ b/run-snippet-tests.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+TRAVIS_PULL_REQUEST="${TRAVIS_PULL_REQUEST:-false}"
+
 function extract_language() {
   path=$1
   previous_part=""


### PR DESCRIPTION
This PR updates the test script to not attempt to push the test reports to s3 automatically so it can be used on dev.