### PR TITLE
KZL-746 Add rules to indent ToC childrens

### DIFF
--- a/src/assets/stylesheets/layout/_sidebar.scss
+++ b/src/assets/stylesheets/layout/_sidebar.scss
@@ -102,6 +102,10 @@ $md-toggle__drawer--checked: '[data-md-toggle="drawer"]:checked ~ .md-container'
     .md-sidebar__inner {
       overflow-x: hidden;
     }
+    
+    .md-nav__list li:not(:first-child) {
+      margin-left: 10px;
+    }
   }
 
   // Wrapper for scrolling on overflow


### PR DESCRIPTION
## What does this PR do?
Add CSS rule to indent ToC childrens on right sidebar menu

### How should this be manually tested?
https://deploy-preview-104--kuzzle-doc-v2.netlify.com/sdk-reference/js/6/kuzzle/add-listener/
