### PR TITLE
SDK Documentation: Janitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,22 @@ jobs:
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
           fi;
 
+    - stage: Snippets tests
+      name: "Temporarily Deploy Kuzzle Docs with failling tests"
+
+      if: type != pull_request AND branch = master
+
+      language: node_js
+      node_js:
+        - "8"
+
+      script:
+        - npm install
+        - npm build
+
+      after_script:
+        - aws s3 sync build/ s3://$AWS_S3_BUCKET/ --delete
+
 # -----------------------------------------------------------------------------
 # Pull Request comment
 # -----------------------------------------------------------------------------
@@ -176,6 +192,3 @@ jobs:
 
       after_deploy:
         - aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
-
-
-

--- a/scaffolding/templates/action.cpp.md
+++ b/scaffolding/templates/action.cpp.md
@@ -1,7 +1,7 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= action %>
+title: <%= _.camelCase(action) %>
 description:
 ---
 

--- a/scaffolding/templates/action.cpp.md
+++ b/scaffolding/templates/action.cpp.md
@@ -1,9 +1,8 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= _.camelCase(action) %>
+title: <%= action %>
 description:
-order: 200
 ---
 
 # <%= _.camelCase(action) %>

--- a/scaffolding/templates/action.go.md
+++ b/scaffolding/templates/action.go.md
@@ -1,9 +1,8 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= _.camelCase(action) %>
+title: <%= action %>
 description:
-order: 200
 ---
 
 # <%= _.camelCase(action) %>

--- a/scaffolding/templates/action.go.md
+++ b/scaffolding/templates/action.go.md
@@ -1,23 +1,21 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= action %>
+title: <%= _.camelCase(action) %>
 description:
 ---
 
 # <%= _.camelCase(action) %>
 
-## Signature
+## Arguments
 
 ```go
 <%= _.upperFirst(_.camelCase(action)) %>() error
 ```
 
-## Arguments
-
-| Arguments    | Type    | Description | Required
-|--------------|---------|-------------|----------
-| ``changeme`` | changme | changeme    | yes
+| Arguments    | Type    | Description |
+|--------------|---------|-------------|
+| ``changeme`` | <pre>changme</pre> | changeme    |
 
 ### **arg1**
 

--- a/scaffolding/templates/action.java.md
+++ b/scaffolding/templates/action.java.md
@@ -1,7 +1,7 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= action %>
+title: <%= _.camelCase(action) %>
 description:
 ---
 

--- a/scaffolding/templates/action.java.md
+++ b/scaffolding/templates/action.java.md
@@ -1,9 +1,8 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= _.camelCase(action) %>
+title: <%= action %>
 description:
-order: 200
 ---
 
 # <%= _.camelCase(action) %>

--- a/scaffolding/templates/action.js.md
+++ b/scaffolding/templates/action.js.md
@@ -1,7 +1,7 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= action %>
+title: <%= _.camelCase(action) %>
 description:
 ---
 

--- a/scaffolding/templates/action.js.md
+++ b/scaffolding/templates/action.js.md
@@ -1,9 +1,8 @@
 ---
 layout: sdk.html.hbs
 algolia: true
-title: <%= _.camelCase(action) %>
+title: <%= action %>
 description:
-order: 200
 ---
 
 # <%= _.camelCase(action) %>

--- a/src/sdk-reference/cpp/1/auth/check-token/index.md
+++ b/src/sdk-reference/cpp/1/auth/check-token/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: checkToken
 description: Checks a JWT Token's validity.
-order: 200
 ---
 
 # checkToken

--- a/src/sdk-reference/cpp/1/auth/create-my-credentials/index.md
+++ b/src/sdk-reference/cpp/1/auth/create-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: createMyCredentials
 description: Create the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # createMyCredentials

--- a/src/sdk-reference/cpp/1/auth/credentials-exist/index.md
+++ b/src/sdk-reference/cpp/1/auth/credentials-exist/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: credentialsExist
 description: Check that the current user has credentials for the specified strategy
-order: 200
 ---
 
 # credentialsExist

--- a/src/sdk-reference/cpp/1/auth/delete-my-credentials/index.md
+++ b/src/sdk-reference/cpp/1/auth/delete-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteMyCredentials
 description: Delete the current user's credentials for the specified strategy
-order: 200
 ---
 
 # deleteMyCredentials

--- a/src/sdk-reference/cpp/1/auth/get-current-user/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-current-user/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getCurrentUser
 description: Returns the profile object for the user linked to the `JSON Web Token`
-order: 200
 ---
 
 # getCurrentUser

--- a/src/sdk-reference/cpp/1/auth/get-my-credentials/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMyCredentials
 description: Returns the current user's credential information for the specified `<strategy>`.
-order: 200
 ---
 
 # getMyCredentials

--- a/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMyRights
 description: Returns the rights for the user linked to the `JSON Web Token`.
-order: 200
 ---
 
 # getMyRights

--- a/src/sdk-reference/cpp/1/auth/get-strategies/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-strategies/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getStrategies
 description: Get all authentication strategies registered in Kuzzle.
-order: 200
 ---
 
 # getStrategies

--- a/src/sdk-reference/cpp/1/auth/index.md
+++ b/src/sdk-reference/cpp/1/auth/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
-title: Auth
-description: Auth Controller
-order: 200
+title: auth
+description: auth controller documentation
 ---
-
-# Auth Controller

--- a/src/sdk-reference/cpp/1/auth/login/index.md
+++ b/src/sdk-reference/cpp/1/auth/login/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: login
 description: Authenticate a user
-order: 200
 ---
 
 # login

--- a/src/sdk-reference/cpp/1/auth/logout/index.md
+++ b/src/sdk-reference/cpp/1/auth/logout/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: logout
 description: Revokes the user's token & unsubscribe them from registered rooms.
-order: 200
 ---
 
 # logout

--- a/src/sdk-reference/cpp/1/auth/update-my-credentials/index.md
+++ b/src/sdk-reference/cpp/1/auth/update-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMyCredentials
 description: Update the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # updateMyCredentials

--- a/src/sdk-reference/cpp/1/auth/update-self/index.md
+++ b/src/sdk-reference/cpp/1/auth/update-self/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSelf
 description: Updates the current user object in Kuzzle.
-order: 200
 ---
 
 # updateSelf

--- a/src/sdk-reference/cpp/1/auth/validate-my-credentials/index.md
+++ b/src/sdk-reference/cpp/1/auth/validate-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateMyCredentials
 description: Validate the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # validateMyCredentials

--- a/src/sdk-reference/cpp/1/collection/create/index.md
+++ b/src/sdk-reference/cpp/1/collection/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create a new collection
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/cpp/1/collection/delete-specifications/index.md
+++ b/src/sdk-reference/cpp/1/collection/delete-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteSpecifications
 description: Delete validation specifications for a collection
-order: 200
 ---
 
 # deleteSpecifications

--- a/src/sdk-reference/cpp/1/collection/exists/index.md
+++ b/src/sdk-reference/cpp/1/collection/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check if collection exists
-order: 200
 ---
 
 # exists

--- a/src/sdk-reference/cpp/1/collection/get-mapping/index.md
+++ b/src/sdk-reference/cpp/1/collection/get-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMapping
 description: Return collection mapping
-order: 200
 ---
 
 # getMapping

--- a/src/sdk-reference/cpp/1/collection/get-specifications/index.md
+++ b/src/sdk-reference/cpp/1/collection/get-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getSpecifications
 description: Returns the validation specifications
-order: 200
 ---
 
 # getSpecifications

--- a/src/sdk-reference/cpp/1/collection/index.md
+++ b/src/sdk-reference/cpp/1/collection/index.md
@@ -1,8 +1,6 @@
 ---
 layout: sdk.html.hbs
-title: Collection
-description: Collection Controller
-order: 200
+title: collection
+description: collection controller documentation
 ---
 
-# Collection Controller

--- a/src/sdk-reference/cpp/1/collection/list/index.md
+++ b/src/sdk-reference/cpp/1/collection/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: Returns the collection list of an index
-order: 200
 ---
 
 # list

--- a/src/sdk-reference/cpp/1/collection/truncate/index.md
+++ b/src/sdk-reference/cpp/1/collection/truncate/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: truncate
 description: Remove all documents from collection
-order: 200
 ---
 
 # truncate

--- a/src/sdk-reference/cpp/1/collection/update-mapping/index.md
+++ b/src/sdk-reference/cpp/1/collection/update-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMapping
 description: Update the collection mapping
-order: 200
 ---
 
 # updateMapping

--- a/src/sdk-reference/cpp/1/collection/update-specifications/index.md
+++ b/src/sdk-reference/cpp/1/collection/update-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSpecifications
 description: Update the validation specifications
-order: 200
 ---
 
 # updateSpecifications

--- a/src/sdk-reference/cpp/1/collection/validate-specifications/index.md
+++ b/src/sdk-reference/cpp/1/collection/validate-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateSpecifications
 description: Validate specifications format
-order: 200
 ---
 
 # validateSpecifications

--- a/src/sdk-reference/cpp/1/essentials/error-handling/index.md
+++ b/src/sdk-reference/cpp/1/essentials/error-handling/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Error Handling
 description: How to handle errors with the SDK
-order: 100
 ---
 
 # Error Handling

--- a/src/sdk-reference/cpp/1/essentials/events/index.md
+++ b/src/sdk-reference/cpp/1/essentials/events/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Events
 description: SDK events system
-order: 100
 ---
 
 # Events

--- a/src/sdk-reference/cpp/1/essentials/realtime-notifications/index.md
+++ b/src/sdk-reference/cpp/1/essentials/realtime-notifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Realtime notifications
 description: List of realtime notifications sent by Kuzzle
-order: 100
 ---
 # Notifications
 

--- a/src/sdk-reference/cpp/1/index/create/index.md
+++ b/src/sdk-reference/cpp/1/index/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create an index
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/cpp/1/index/delete/index.md
+++ b/src/sdk-reference/cpp/1/index/delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: delete
 description: Deletes an index
-order: 500
 ---
 
 # Delete

--- a/src/sdk-reference/cpp/1/index/exists/index.md
+++ b/src/sdk-reference/cpp/1/index/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check for index existence
-order: 300
 ---
 
 # Exists

--- a/src/sdk-reference/cpp/1/index/get-auto-refresh/index.md
+++ b/src/sdk-reference/cpp/1/index/get-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getAutoRefresh
 description: Returns the status of autorefresh flag
-order: 900
 ---
 
 # GetAutoRefresh

--- a/src/sdk-reference/cpp/1/index/index.md
+++ b/src/sdk-reference/cpp/1/index/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
-title: Index
-description: Index Controller
-order: 200
+title: index
+description: index controller documentation
 ---
-
-# Index Controller

--- a/src/sdk-reference/cpp/1/index/list/index.md
+++ b/src/sdk-reference/cpp/1/index/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: List the indexes
-order: 400
 ---
 
 # List

--- a/src/sdk-reference/cpp/1/index/m-delete/index.md
+++ b/src/sdk-reference/cpp/1/index/m-delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: mDelete
 description: Deletes multiple indexes
-order: 600
 ---
 
 # mDelete

--- a/src/sdk-reference/cpp/1/index/refresh-internal/index.md
+++ b/src/sdk-reference/cpp/1/index/refresh-internal/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refreshInternal
 description: Force refresh of Kuzzle internal index
-order: 800
 ---
 
 # RefreshInternal

--- a/src/sdk-reference/cpp/1/index/refresh/index.md
+++ b/src/sdk-reference/cpp/1/index/refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refresh
 description: Force Elasticsearch search index update
-order: 700
 ---
 
 # Refresh

--- a/src/sdk-reference/cpp/1/index/set-auto-refresh/index.md
+++ b/src/sdk-reference/cpp/1/index/set-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: setAutoRefresh
 description: Set the autorefresh flag
-order: 1000
 ---
 
 # setAutoRefresh(index, autorefresh, [options])

--- a/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/add-listener/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: addListener
 description: Add a listener to an event
-order: 200
 ---
 
 # addListener

--- a/src/sdk-reference/cpp/1/kuzzle/connect/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/connect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: connect
 description: Connects the SDK to Kuzzle
-order: 200
 ---
 
 # connect

--- a/src/sdk-reference/cpp/1/kuzzle/constructor/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/constructor/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Constructor
 description: Create a new Kuzzle object connected to the backend
-order: 150
 ---
 
 # Constructor

--- a/src/sdk-reference/cpp/1/kuzzle/disconnect/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/disconnect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: disconnect
 description: Disconnect the SDK
-order: 200
 ---
 
 # disconnect

--- a/src/sdk-reference/cpp/1/kuzzle/flush-queue/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/flush-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: flushQueue
 description: Empties the offline request queue
-order: 200
 ---
 
 # flushQueue

--- a/src/sdk-reference/cpp/1/kuzzle/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/index.md
@@ -4,5 +4,3 @@ title: Kuzzle
 description: Kuzzle object
 order: 100
 ---
-
-# Kuzzle object

--- a/src/sdk-reference/cpp/1/kuzzle/play-queue/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/play-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: playQueue
 description: Play the offline request queue
-order: 200
 ---
 
 # playQueue

--- a/src/sdk-reference/cpp/1/kuzzle/query/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/query/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: query
 description: Base method to send API query to Kuzzle
-order: 200
 ---
 
 # query

--- a/src/sdk-reference/cpp/1/kuzzle/start-queuing/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/start-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: startQueuing
 description: Starts the requests queuing
-order: 200
 ---
 
 # startQueuing

--- a/src/sdk-reference/cpp/1/kuzzle/stop-queuing/index.md
+++ b/src/sdk-reference/cpp/1/kuzzle/stop-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: stopQueuing
 description: Stops the requests queuing
-order: 200
 ---
 
 # stopQueuing

--- a/src/sdk-reference/go/1/auth/check-token/index.md
+++ b/src/sdk-reference/go/1/auth/check-token/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: CheckToken
 description: Checks a JWT Token's validity.
-order: 200
 ---
 
 # CheckToken

--- a/src/sdk-reference/go/1/auth/create-my-credentials/index.md
+++ b/src/sdk-reference/go/1/auth/create-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: CreateMyCredentials
 description: Create the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # CreateMyCredentials

--- a/src/sdk-reference/go/1/auth/credentials-exist/index.md
+++ b/src/sdk-reference/go/1/auth/credentials-exist/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: CredentialsExist
 description: Check that the current user has credentials for the specified strategy
-order: 200
 ---
 
 # CredentialsExist

--- a/src/sdk-reference/go/1/auth/delete-my-credentials/index.md
+++ b/src/sdk-reference/go/1/auth/delete-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: DeleteMyCredentials
 description: Delete the current user's credentials for the specified strategy
-order: 200
 ---
 
 # DeleteMyCredentials

--- a/src/sdk-reference/go/1/auth/get-current-user/index.md
+++ b/src/sdk-reference/go/1/auth/get-current-user/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: GetCurrentUser
 description: Returns the profile object for the user linked to the `JSON Web Token`
-order: 200
 ---
 
 # GetCurrentUser

--- a/src/sdk-reference/go/1/auth/get-my-credentials/index.md
+++ b/src/sdk-reference/go/1/auth/get-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: GetMyCredentials
 description:
-order: 200
 ---
 
 # GetMyCredentials

--- a/src/sdk-reference/go/1/auth/get-my-rights/index.md
+++ b/src/sdk-reference/go/1/auth/get-my-rights/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: GetMyRights
 description: Returns the rights for the user linked to the `JSON Web Token`.
-order: 200
 ---
 
 # GetMyRights

--- a/src/sdk-reference/go/1/auth/get-strategies/index.md
+++ b/src/sdk-reference/go/1/auth/get-strategies/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: GetStrategies
 description: Get all authentication strategies registered in Kuzzle.
-order: 200
 ---
 
 # GetStrategies

--- a/src/sdk-reference/go/1/auth/index.md
+++ b/src/sdk-reference/go/1/auth/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
 title: Auth
-description: Auth Controller
-order: 200
+description: Auth controller documentation
 ---
-
-# Auth Controller

--- a/src/sdk-reference/go/1/auth/login/index.md
+++ b/src/sdk-reference/go/1/auth/login/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Login
 description: Authenticate a user
-order: 200
 ---
 
 # Login

--- a/src/sdk-reference/go/1/auth/logout/index.md
+++ b/src/sdk-reference/go/1/auth/logout/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Logout
 description: Revokes the user's token & unsubscribe them from registered rooms.
-order: 200
 ---
 
 # Logout

--- a/src/sdk-reference/go/1/auth/update-my-credentials/index.md
+++ b/src/sdk-reference/go/1/auth/update-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: UpdateMyCredentials
 description: Update the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # UpdateMyCredentials

--- a/src/sdk-reference/go/1/auth/update-self/index.md
+++ b/src/sdk-reference/go/1/auth/update-self/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: UpdateSelf
 description: Updates the current user object in Kuzzle.
-order: 200
 ---
 
 # UpdateSelf

--- a/src/sdk-reference/go/1/auth/validate-my-credentials/index.md
+++ b/src/sdk-reference/go/1/auth/validate-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: ValidateMyCredentials
 description: Validate the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # ValidateMyCredentials

--- a/src/sdk-reference/go/1/collection/create/index.md
+++ b/src/sdk-reference/go/1/collection/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create a new collection
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/go/1/collection/delete-specifications/index.md
+++ b/src/sdk-reference/go/1/collection/delete-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteSpecifications
 description: Delete validation specifications for a collection
-order: 200
 ---
 
 # deleteSpecifications

--- a/src/sdk-reference/go/1/collection/exists/index.md
+++ b/src/sdk-reference/go/1/collection/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check if collection exists
-order: 200
 ---
 
 # exists

--- a/src/sdk-reference/go/1/collection/get-mapping/index.md
+++ b/src/sdk-reference/go/1/collection/get-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMapping
 description: Return collection mapping
-order: 200
 ---
 
 # getMapping

--- a/src/sdk-reference/go/1/collection/get-specifications/index.md
+++ b/src/sdk-reference/go/1/collection/get-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getSpecifications
 description: Returns the validation specifications
-order: 200
 ---
 
 # getSpecifications

--- a/src/sdk-reference/go/1/collection/index.md
+++ b/src/sdk-reference/go/1/collection/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: Collection
 description: Collection Controller
-order: 200
 ---
 
 # Collection Controller

--- a/src/sdk-reference/go/1/collection/list/index.md
+++ b/src/sdk-reference/go/1/collection/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: Returns the collection list of an index
-order: 200
 ---
 
 # list

--- a/src/sdk-reference/go/1/collection/truncate/index.md
+++ b/src/sdk-reference/go/1/collection/truncate/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: truncate
 description: Remove all documents from collection
-order: 200
 ---
 
 # truncate

--- a/src/sdk-reference/go/1/collection/update-mapping/index.md
+++ b/src/sdk-reference/go/1/collection/update-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMapping
 description: Update the collection mapping
-order: 200
 ---
 
 # updateMapping

--- a/src/sdk-reference/go/1/collection/update-specifications/index.md
+++ b/src/sdk-reference/go/1/collection/update-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSpecifications
 description: Update the validation specifications
-order: 200
 ---
 
 # updateSpecifications

--- a/src/sdk-reference/go/1/collection/validate-specifications/index.md
+++ b/src/sdk-reference/go/1/collection/validate-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateSpecifications
 description: Validate specifications format
-order: 200
 ---
 
 # validateSpecifications

--- a/src/sdk-reference/go/1/essentials/error-handling/index.md
+++ b/src/sdk-reference/go/1/essentials/error-handling/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Error Handling
 description: How to handle errors with the SDK
-order: 100
 ---
 
 # Error Handling

--- a/src/sdk-reference/go/1/essentials/events/index.md
+++ b/src/sdk-reference/go/1/essentials/events/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Events
 description: SDK events system
-order: 100
 ---
 
 # Events

--- a/src/sdk-reference/go/1/essentials/realtime-notifications/index.md
+++ b/src/sdk-reference/go/1/essentials/realtime-notifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Realtime notifications
 description: List of realtime notifications sent by Kuzzle
-order: 100
 ---
 # Notifications
 

--- a/src/sdk-reference/go/1/index/create/index.md
+++ b/src/sdk-reference/go/1/index/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create an index
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/go/1/index/delete/index.md
+++ b/src/sdk-reference/go/1/index/delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: delete
 description: Deletes an index
-order: 500
 ---
 
 # Delete

--- a/src/sdk-reference/go/1/index/exists/index.md
+++ b/src/sdk-reference/go/1/index/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check for index existence
-order: 300
 ---
 
 # Exists

--- a/src/sdk-reference/go/1/index/get-auto-refresh/index.md
+++ b/src/sdk-reference/go/1/index/get-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getAutoRefresh
 description: Returns the status of autorefresh flag
-order: 900
 ---
 
 # GetAutoRefresh

--- a/src/sdk-reference/go/1/index/index.md
+++ b/src/sdk-reference/go/1/index/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: Index
 description: Index Controller
-order: 200
 ---
 
 # Index Controller

--- a/src/sdk-reference/go/1/index/list/index.md
+++ b/src/sdk-reference/go/1/index/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: List the indexes
-order: 400
 ---
 
 # List

--- a/src/sdk-reference/go/1/index/m-delete/index.md
+++ b/src/sdk-reference/go/1/index/m-delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: mDelete
 description: Deletes multiple indexes
-order: 600
 ---
 
 # mDelete

--- a/src/sdk-reference/go/1/index/refresh-internal/index.md
+++ b/src/sdk-reference/go/1/index/refresh-internal/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refreshInternal
 description: Force refresh of Kuzzle internal index
-order: 800
 ---
 
 # RefreshInternal

--- a/src/sdk-reference/go/1/index/refresh/index.md
+++ b/src/sdk-reference/go/1/index/refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refresh
 description: Force Elasticsearch search index update
-order: 700
 ---
 
 # Refresh

--- a/src/sdk-reference/go/1/index/set-auto-refresh/index.md
+++ b/src/sdk-reference/go/1/index/set-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: setAutoRefresh
 description: Set the autorefresh flag
-order: 1000
 ---
 
 # setAutoRefresh(index, autorefresh, [options])

--- a/src/sdk-reference/go/1/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/go/1/kuzzle/add-listener/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: addListener
 description: Add a listener to an event
-order: 200
 ---
 
 # addListener

--- a/src/sdk-reference/go/1/kuzzle/connect/index.md
+++ b/src/sdk-reference/go/1/kuzzle/connect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: connect
 description: Connects the SDK to Kuzzle
-order: 200
 ---
 
 # connect

--- a/src/sdk-reference/go/1/kuzzle/constructor/index.md
+++ b/src/sdk-reference/go/1/kuzzle/constructor/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Constructor
 description: Create a new Kuzzle object connected to the backend
-order: 150
 ---
 
 # Constructor

--- a/src/sdk-reference/go/1/kuzzle/disconnect/index.md
+++ b/src/sdk-reference/go/1/kuzzle/disconnect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: disconnect
 description: Disconnect the SDK
-order: 200
 ---
 
 # disconnect

--- a/src/sdk-reference/go/1/kuzzle/flush-queue/index.md
+++ b/src/sdk-reference/go/1/kuzzle/flush-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: flushQueue
 description: Empties the offline request queue
-order: 200
 ---
 
 # flushQueue

--- a/src/sdk-reference/go/1/kuzzle/play-queue/index.md
+++ b/src/sdk-reference/go/1/kuzzle/play-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: playQueue
 description: Play the offline request queue
-order: 200
 ---
 
 # playQueue

--- a/src/sdk-reference/go/1/kuzzle/query/index.md
+++ b/src/sdk-reference/go/1/kuzzle/query/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: query
 description: Base method to send API query to Kuzzle
-order: 200
 ---
 
 # query

--- a/src/sdk-reference/go/1/kuzzle/start-queuing/index.md
+++ b/src/sdk-reference/go/1/kuzzle/start-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: startQueuing
 description: Starts the requests queuing
-order: 200
 ---
 
 # startQueuing

--- a/src/sdk-reference/go/1/kuzzle/stop-queuing/index.md
+++ b/src/sdk-reference/go/1/kuzzle/stop-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: stopQueuing
 description: Stops the requests queuing
-order: 200
 ---
 
 # stopQueuing

--- a/src/sdk-reference/java/1/auth/check-token/index.md
+++ b/src/sdk-reference/java/1/auth/check-token/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: checkToken
 description: Checks a JWT Token's validity.
-order: 200
 ---
 
 # checkToken

--- a/src/sdk-reference/java/1/auth/create-my-credentials/index.md
+++ b/src/sdk-reference/java/1/auth/create-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: createMyCredentials
 description: Create the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # createMyCredentials

--- a/src/sdk-reference/java/1/auth/credentials-exist/index.md
+++ b/src/sdk-reference/java/1/auth/credentials-exist/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: credentialsExist
 description: Check that the current user has credentials for the specified strategy
-order: 200
 ---
 
 # credentialsExist

--- a/src/sdk-reference/java/1/auth/delete-my-credentials/index.md
+++ b/src/sdk-reference/java/1/auth/delete-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteMyCredentials
 description: Delete the current user's credentials for the specified strategy
-order: 200
 ---
 
 # deleteMyCredentials

--- a/src/sdk-reference/java/1/auth/get-current-user/index.md
+++ b/src/sdk-reference/java/1/auth/get-current-user/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getCurrentUser
 description: Returns the profile object for the user linked to the `JSON Web Token`
-order: 200
 ---
 
 # getCurrentUser

--- a/src/sdk-reference/java/1/auth/get-my-credentials/index.md
+++ b/src/sdk-reference/java/1/auth/get-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMyCredentials
 description:
-order: 200
 ---
 
 # getMyCredentials

--- a/src/sdk-reference/java/1/auth/get-my-rights/index.md
+++ b/src/sdk-reference/java/1/auth/get-my-rights/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMyRights
 description: Returns the rights for the user linked to the `JSON Web Token`.
-order: 200
 ---
 
 # getMyRights

--- a/src/sdk-reference/java/1/auth/get-strategies/index.md
+++ b/src/sdk-reference/java/1/auth/get-strategies/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getStrategies
 description: Get all authentication strategies registered in Kuzzle.
-order: 200
 ---
 
 # getStrategies

--- a/src/sdk-reference/java/1/auth/index.md
+++ b/src/sdk-reference/java/1/auth/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: Auth
 description: Auth Controller
-order: 200
 ---
 
 # Auth Controller

--- a/src/sdk-reference/java/1/auth/login/index.md
+++ b/src/sdk-reference/java/1/auth/login/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: login
 description: Authenticate a user
-order: 200
 ---
 
 # login

--- a/src/sdk-reference/java/1/auth/logout/index.md
+++ b/src/sdk-reference/java/1/auth/logout/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: logout
 description: Revokes the user's token & unsubscribe them from registered rooms.
-order: 200
 ---
 
 # logout

--- a/src/sdk-reference/java/1/auth/update-my-credentials/index.md
+++ b/src/sdk-reference/java/1/auth/update-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMyCredentials
 description: Update the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # updateMyCredentials

--- a/src/sdk-reference/java/1/auth/update-self/index.md
+++ b/src/sdk-reference/java/1/auth/update-self/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSelf
 description: Updates the current user object in Kuzzle.
-order: 200
 ---
 
 # updateSelf

--- a/src/sdk-reference/java/1/auth/validate-my-credentials/index.md
+++ b/src/sdk-reference/java/1/auth/validate-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateMyCredentials
 description: Validate the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # validateMyCredentials

--- a/src/sdk-reference/java/1/collection/create/index.md
+++ b/src/sdk-reference/java/1/collection/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create a new collection
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/java/1/collection/delete-specifications/index.md
+++ b/src/sdk-reference/java/1/collection/delete-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteSpecifications
 description: Delete validation specifications for a collection
-order: 200
 ---
 
 # deleteSpecifications

--- a/src/sdk-reference/java/1/collection/exists/index.md
+++ b/src/sdk-reference/java/1/collection/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check if collection exists
-order: 200
 ---
 
 # exists

--- a/src/sdk-reference/java/1/collection/get-mapping/index.md
+++ b/src/sdk-reference/java/1/collection/get-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMapping
 description: Return collection mapping
-order: 200
 ---
 
 # getMapping

--- a/src/sdk-reference/java/1/collection/get-specifications/index.md
+++ b/src/sdk-reference/java/1/collection/get-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getSpecifications
 description: Returns the validation specifications
-order: 200
 ---
 
 # getSpecifications

--- a/src/sdk-reference/java/1/collection/index.md
+++ b/src/sdk-reference/java/1/collection/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: Collection
 description: Collection Controller
-order: 200
 ---
 
 # Collection Controller

--- a/src/sdk-reference/java/1/collection/list/index.md
+++ b/src/sdk-reference/java/1/collection/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: Returns the collection list of an index
-order: 200
 ---
 
 # list

--- a/src/sdk-reference/java/1/collection/truncate/index.md
+++ b/src/sdk-reference/java/1/collection/truncate/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: truncate
 description: Remove all documents from collection
-order: 200
 ---
 
 # truncate

--- a/src/sdk-reference/java/1/collection/update-mapping/index.md
+++ b/src/sdk-reference/java/1/collection/update-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMapping
 description: Update the collection mapping
-order: 200
 ---
 
 # updateMapping

--- a/src/sdk-reference/java/1/collection/update-specifications/index.md
+++ b/src/sdk-reference/java/1/collection/update-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSpecifications
 description: Update the validation specifications
-order: 200
 ---
 
 # updateSpecifications

--- a/src/sdk-reference/java/1/collection/validate-specifications/index.md
+++ b/src/sdk-reference/java/1/collection/validate-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateSpecifications
 description: Validate specifications format
-order: 200
 ---
 
 # validateSpecifications

--- a/src/sdk-reference/java/1/essentials/error-handling/index.md
+++ b/src/sdk-reference/java/1/essentials/error-handling/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Error Handling
 description: How to handle errors with the SDK
-order: 100
 ---
 
 # Error Handling

--- a/src/sdk-reference/java/1/essentials/events/index.md
+++ b/src/sdk-reference/java/1/essentials/events/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Events
 description: SDK events system
-order: 100
 ---
 
 # Events

--- a/src/sdk-reference/java/1/essentials/realtime-notifications/index.md
+++ b/src/sdk-reference/java/1/essentials/realtime-notifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Realtime notifications
 description: List of realtime notifications sent by Kuzzle
-order: 100
 ---
 # Notifications
 

--- a/src/sdk-reference/java/1/index/create/index.md
+++ b/src/sdk-reference/java/1/index/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create an index
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/java/1/index/delete/index.md
+++ b/src/sdk-reference/java/1/index/delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: delete
 description: Deletes an index
-order: 500
 ---
 
 # Delete

--- a/src/sdk-reference/java/1/index/exists/index.md
+++ b/src/sdk-reference/java/1/index/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check for index existence
-order: 300
 ---
 
 # Exists

--- a/src/sdk-reference/java/1/index/get-auto-refresh/index.md
+++ b/src/sdk-reference/java/1/index/get-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getAutoRefresh
 description: Returns the status of autorefresh flag
-order: 900
 ---
 
 # GetAutoRefresh

--- a/src/sdk-reference/java/1/index/index.md
+++ b/src/sdk-reference/java/1/index/index.md
@@ -2,7 +2,6 @@
 layout: sdk.html.hbs
 title: Index
 description: Index Controller
-order: 200
 ---
 
 # Index Controller

--- a/src/sdk-reference/java/1/index/list/index.md
+++ b/src/sdk-reference/java/1/index/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: List the indexes
-order: 400
 ---
 
 # List

--- a/src/sdk-reference/java/1/index/m-delete/index.md
+++ b/src/sdk-reference/java/1/index/m-delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: mDelete
 description: Deletes multiple indexes
-order: 600
 ---
 
 # mDelete

--- a/src/sdk-reference/java/1/index/refresh-internal/index.md
+++ b/src/sdk-reference/java/1/index/refresh-internal/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refreshInternal
 description: Force refresh of Kuzzle internal index
-order: 800
 ---
 
 # RefreshInternal

--- a/src/sdk-reference/java/1/index/refresh/index.md
+++ b/src/sdk-reference/java/1/index/refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refresh
 description: Force Elasticsearch search index update
-order: 700
 ---
 
 # Refresh

--- a/src/sdk-reference/java/1/index/set-auto-refresh/index.md
+++ b/src/sdk-reference/java/1/index/set-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: setAutoRefresh
 description: Set the autorefresh flag
-order: 1000
 ---
 
 # setAutoRefresh(index, autorefresh, [options])

--- a/src/sdk-reference/java/1/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/java/1/kuzzle/add-listener/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: addListener
 description: Add a listener to an event
-order: 200
 ---
 
 # addListener

--- a/src/sdk-reference/java/1/kuzzle/connect/index.md
+++ b/src/sdk-reference/java/1/kuzzle/connect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: connect
 description: Connects the SDK to Kuzzle
-order: 200
 ---
 
 # connect

--- a/src/sdk-reference/java/1/kuzzle/constructor/index.md
+++ b/src/sdk-reference/java/1/kuzzle/constructor/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Constructor
 description: Create a new Kuzzle object connected to the backend
-order: 150
 ---
 
 # Constructor

--- a/src/sdk-reference/java/1/kuzzle/disconnect/index.md
+++ b/src/sdk-reference/java/1/kuzzle/disconnect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: disconnect
 description: Disconnect the SDK
-order: 200
 ---
 
 # disconnect

--- a/src/sdk-reference/java/1/kuzzle/flush-queue/index.md
+++ b/src/sdk-reference/java/1/kuzzle/flush-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: flushQueue
 description: Empties the offline request queue
-order: 200
 ---
 
 # flushQueue

--- a/src/sdk-reference/java/1/kuzzle/play-queue/index.md
+++ b/src/sdk-reference/java/1/kuzzle/play-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: playQueue
 description: Play the offline request queue
-order: 200
 ---
 
 # playQueue

--- a/src/sdk-reference/java/1/kuzzle/query/index.md
+++ b/src/sdk-reference/java/1/kuzzle/query/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: query
 description: Base method to send API query to Kuzzle
-order: 200
 ---
 
 # query

--- a/src/sdk-reference/java/1/kuzzle/start-queuing/index.md
+++ b/src/sdk-reference/java/1/kuzzle/start-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: startQueuing
 description: Starts the requests queuing
-order: 200
 ---
 
 # startQueuing

--- a/src/sdk-reference/java/1/kuzzle/stop-queuing/index.md
+++ b/src/sdk-reference/java/1/kuzzle/stop-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: stopQueuing
 description: Stops the requests queuing
-order: 200
 ---
 
 # stopQueuing

--- a/src/sdk-reference/js/6/auth/check-token/index.md
+++ b/src/sdk-reference/js/6/auth/check-token/index.md
@@ -2,8 +2,6 @@
 layout: sdk.html.hbs
 algolia: true
 title: checkToken
-description:
-order: 200
 ---
 
 # checkToken

--- a/src/sdk-reference/js/6/auth/create-my-credentials/index.md
+++ b/src/sdk-reference/js/6/auth/create-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: createMyCredentials
 description: Create the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # createMyCredentials

--- a/src/sdk-reference/js/6/auth/credentials-exist/index.md
+++ b/src/sdk-reference/js/6/auth/credentials-exist/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: credentialsExist
 description: Check that the current user has credentials for the specified strategy
-order: 200
 ---
 
 # credentialsExist

--- a/src/sdk-reference/js/6/auth/delete-my-credentials/index.md
+++ b/src/sdk-reference/js/6/auth/delete-my-credentials/index.md
@@ -2,8 +2,6 @@
 layout: sdk.html.hbs
 algolia: true
 title: deleteMyCredentials
-description:
-order: 200
 ---
 
 # deleteMyCredentials

--- a/src/sdk-reference/js/6/auth/get-current-user/index.md
+++ b/src/sdk-reference/js/6/auth/get-current-user/index.md
@@ -2,8 +2,6 @@
 layout: sdk.html.hbs
 algolia: true
 title: getCurrentUser
-description:
-order: 200
 ---
 
 # getCurrentUser

--- a/src/sdk-reference/js/6/auth/get-my-credentials/index.md
+++ b/src/sdk-reference/js/6/auth/get-my-credentials/index.md
@@ -2,8 +2,6 @@
 layout: sdk.html.hbs
 algolia: true
 title: getMyCredentials
-description:
-order: 200
 ---
 
 # getMyCredentials

--- a/src/sdk-reference/js/6/auth/get-my-rights/index.md
+++ b/src/sdk-reference/js/6/auth/get-my-rights/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMyRights
 description: Returns the rights for the user linked to the `JSON Web Token`.
-order: 200
 ---
 
 # getMyRights

--- a/src/sdk-reference/js/6/auth/get-strategies/index.md
+++ b/src/sdk-reference/js/6/auth/get-strategies/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getStrategies
 description: Get all authentication strategies registered in Kuzzle.
-order: 200
 ---
 
 # getStrategies

--- a/src/sdk-reference/js/6/auth/index.md
+++ b/src/sdk-reference/js/6/auth/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
-title: Auth
-description: Auth Controller
-order: 200
+title: auth
+description: auth controller documentation
 ---
-
-# Auth Controller

--- a/src/sdk-reference/js/6/auth/login/index.md
+++ b/src/sdk-reference/js/6/auth/login/index.md
@@ -2,8 +2,6 @@
 layout: sdk.html.hbs
 algolia: true
 title: login
-description:
-order: 200
 ---
 
 # login

--- a/src/sdk-reference/js/6/auth/logout/index.md
+++ b/src/sdk-reference/js/6/auth/logout/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: logout
 description: Revokes the user's token & unsubscribe them from registered rooms.
-order: 200
 ---
 
 # logout

--- a/src/sdk-reference/js/6/auth/update-my-credentials/index.md
+++ b/src/sdk-reference/js/6/auth/update-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMyCredentials
 description: Update the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # updateMyCredentials

--- a/src/sdk-reference/js/6/auth/update-self/index.md
+++ b/src/sdk-reference/js/6/auth/update-self/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSelf
 description: Updates the current user object in Kuzzle.
-order: 200
 ---
 
 # updateSelf

--- a/src/sdk-reference/js/6/auth/validate-my-credentials/index.md
+++ b/src/sdk-reference/js/6/auth/validate-my-credentials/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateMyCredentials
 description: Validate the current user's credentials for the specified `<strategy>`.
-order: 200
 ---
 
 # validateMyCredentials

--- a/src/sdk-reference/js/6/bulk/import/index.md
+++ b/src/sdk-reference/js/6/bulk/import/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: import
 description: Performs a bulk import on a collection
-order: 200
 ---
 
 # Import

--- a/src/sdk-reference/js/6/bulk/index.md
+++ b/src/sdk-reference/js/6/bulk/index.md
@@ -1,8 +1,6 @@
 ---
 layout: sdk.html.hbs
-title: Bulk
-description: Bulk Controller
-order: 200
+title: bulk
+description: bulk controller documentation
 ---
 
-# Bulk Controller

--- a/src/sdk-reference/js/6/collection/create/index.md
+++ b/src/sdk-reference/js/6/collection/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create a new collection
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/js/6/collection/delete-specifications/index.md
+++ b/src/sdk-reference/js/6/collection/delete-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: deleteSpecifications
 description: Delete validation specifications for a collection
-order: 200
 ---
 
 # deleteSpecifications

--- a/src/sdk-reference/js/6/collection/exists/index.md
+++ b/src/sdk-reference/js/6/collection/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check if collection exists
-order: 200
 ---
 
 # exists

--- a/src/sdk-reference/js/6/collection/get-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/get-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getMapping
 description: Return collection mapping
-order: 200
 ---
 
 # getMapping

--- a/src/sdk-reference/js/6/collection/get-specifications/index.md
+++ b/src/sdk-reference/js/6/collection/get-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getSpecifications
 description: Returns the validation specifications
-order: 200
 ---
 
 # getSpecifications

--- a/src/sdk-reference/js/6/collection/index.md
+++ b/src/sdk-reference/js/6/collection/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
-title: Collection
-description: Collection Controller
-order: 200
+title: collection
+description: collection controller documentation
 ---
-
-# Collection Controller

--- a/src/sdk-reference/js/6/collection/list/index.md
+++ b/src/sdk-reference/js/6/collection/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: Returns the collection list of an index
-order: 200
 ---
 
 # list

--- a/src/sdk-reference/js/6/collection/search-specifications/index.md
+++ b/src/sdk-reference/js/6/collection/search-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: searchSpecifications
 description: Search for specifications
-order: 200
 ---
 
 # searchSpecifications

--- a/src/sdk-reference/js/6/collection/truncate/index.md
+++ b/src/sdk-reference/js/6/collection/truncate/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: truncate
 description: Remove all documents from collection
-order: 200
 ---
 
 # truncate

--- a/src/sdk-reference/js/6/collection/update-mapping/index.md
+++ b/src/sdk-reference/js/6/collection/update-mapping/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateMapping
 description: Update the collection mapping
-order: 200
 ---
 
 # updateMapping

--- a/src/sdk-reference/js/6/collection/update-specifications/index.md
+++ b/src/sdk-reference/js/6/collection/update-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: updateSpecifications
 description: Update the validation specifications
-order: 200
 ---
 
 # updateSpecifications

--- a/src/sdk-reference/js/6/collection/validate-specifications/index.md
+++ b/src/sdk-reference/js/6/collection/validate-specifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: validateSpecifications
 description: Validate specifications format
-order: 200
 ---
 
 # validateSpecifications

--- a/src/sdk-reference/js/6/essentials/error-handling/index.md
+++ b/src/sdk-reference/js/6/essentials/error-handling/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Error Handling
 description: How to handle errors with the SDK
-order: 100
 ---
 
 # Error Handling

--- a/src/sdk-reference/js/6/essentials/events/index.md
+++ b/src/sdk-reference/js/6/essentials/events/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Events
 description: SDK events system
-order: 100
 ---
 
 # Events

--- a/src/sdk-reference/js/6/essentials/realtime-notifications/index.md
+++ b/src/sdk-reference/js/6/essentials/realtime-notifications/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Realtime notifications
 description: List of realtime notifications sent by Kuzzle
-order: 100
 ---
 # Notifications
 

--- a/src/sdk-reference/js/6/index/create/index.md
+++ b/src/sdk-reference/js/6/index/create/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: create
 description: Create an index
-order: 200
 ---
 
 # create

--- a/src/sdk-reference/js/6/index/delete/index.md
+++ b/src/sdk-reference/js/6/index/delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: delete
 description: Deletes an index
-order: 500
 ---
 
 # Delete

--- a/src/sdk-reference/js/6/index/exists/index.md
+++ b/src/sdk-reference/js/6/index/exists/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: exists
 description: Check for index existence
-order: 300
 ---
 
 # Exists

--- a/src/sdk-reference/js/6/index/get-auto-refresh/index.md
+++ b/src/sdk-reference/js/6/index/get-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: getAutoRefresh
 description: Returns the status of autorefresh flag
-order: 900
 ---
 
 # GetAutoRefresh

--- a/src/sdk-reference/js/6/index/index.md
+++ b/src/sdk-reference/js/6/index/index.md
@@ -1,8 +1,5 @@
 ---
 layout: sdk.html.hbs
-title: Index
-description: Index Controller
-order: 200
+title: index
+description: index controller documentation
 ---
-
-# Index Controller

--- a/src/sdk-reference/js/6/index/list/index.md
+++ b/src/sdk-reference/js/6/index/list/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: list
 description: List the indexes
-order: 400
 ---
 
 # List

--- a/src/sdk-reference/js/6/index/m-delete/index.md
+++ b/src/sdk-reference/js/6/index/m-delete/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: mDelete
 description: Deletes multiple indexes
-order: 600
 ---
 
 # mDelete

--- a/src/sdk-reference/js/6/index/refresh-internal/index.md
+++ b/src/sdk-reference/js/6/index/refresh-internal/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refreshInternal
 description: Force refresh of Kuzzle internal index
-order: 800
 ---
 
 # RefreshInternal

--- a/src/sdk-reference/js/6/index/refresh/index.md
+++ b/src/sdk-reference/js/6/index/refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: refresh
 description: Force Elasticsearch search index update
-order: 700
 ---
 
 # Refresh

--- a/src/sdk-reference/js/6/index/set-auto-refresh/index.md
+++ b/src/sdk-reference/js/6/index/set-auto-refresh/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: setAutoRefresh
 description: Set the autorefresh flag
-order: 1000
 ---
 
 # setAutoRefresh(index, autorefresh, [options])

--- a/src/sdk-reference/js/6/kuzzle/add-listener/index.md
+++ b/src/sdk-reference/js/6/kuzzle/add-listener/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: addListener
 description: Add a listener to an event
-order: 200
 ---
 
 # addListener

--- a/src/sdk-reference/js/6/kuzzle/connect/index.md
+++ b/src/sdk-reference/js/6/kuzzle/connect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: connect
 description: Connects the SDK to Kuzzle
-order: 200
 ---
 
 # connect

--- a/src/sdk-reference/js/6/kuzzle/constructor/index.md
+++ b/src/sdk-reference/js/6/kuzzle/constructor/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: Constructor
 description: Create a new Kuzzle object connected to the backend
-order: 150
 ---
 
 # Constructor

--- a/src/sdk-reference/js/6/kuzzle/disconnect/index.md
+++ b/src/sdk-reference/js/6/kuzzle/disconnect/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: disconnect
 description: Disconnect the SDK
-order: 200
 ---
 
 # disconnect

--- a/src/sdk-reference/js/6/kuzzle/flush-queue/index.md
+++ b/src/sdk-reference/js/6/kuzzle/flush-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: flushQueue
 description: Empties the offline request queue
-order: 200
 ---
 
 # flushQueue

--- a/src/sdk-reference/js/6/kuzzle/index.md
+++ b/src/sdk-reference/js/6/kuzzle/index.md
@@ -1,8 +1,6 @@
 ---
 layout: full.html.hbs
 title: Kuzzle
-description: Kuzzle object
+description: Kuzzle object documentation
 order: 100
 ---
-
-# Kuzzle object

--- a/src/sdk-reference/js/6/kuzzle/play-queue/index.md
+++ b/src/sdk-reference/js/6/kuzzle/play-queue/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: playQueue
 description: Play the offline request queue
-order: 200
 ---
 
 # playQueue

--- a/src/sdk-reference/js/6/kuzzle/query/index.md
+++ b/src/sdk-reference/js/6/kuzzle/query/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: query
 description: Base method to send API query to Kuzzle
-order: 200
 ---
 
 # query

--- a/src/sdk-reference/js/6/kuzzle/start-queuing/index.md
+++ b/src/sdk-reference/js/6/kuzzle/start-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: startQueuing
 description: Starts the requests queuing
-order: 200
 ---
 
 # startQueuing

--- a/src/sdk-reference/js/6/kuzzle/stop-queuing/index.md
+++ b/src/sdk-reference/js/6/kuzzle/stop-queuing/index.md
@@ -3,7 +3,6 @@ layout: sdk.html.hbs
 algolia: true
 title: stopQueuing
 description: Stops the requests queuing
-order: 200
 ---
 
 # stopQueuing


### PR DESCRIPTION
# Description

* Remove unneeded `order` metalsmith arguments: pages without order are automatically put at the end of the navigation list, and sorted alphabetically amongst them. So that argument is only needed to force items to appear at specific places in the navigation, e.g. `Essentials` pages are often required to be put at the very beginning of a section
* Lowercase controller names for Javascript and C++, as it is perturbing to access the `auth` controller referred in the documentation as the `Auth` controller.
  * Go is obviously not concerned since controller names are uppercased
  * Java is a bit tricky, since we use getters to access controllers. So I left them uppercased, as to document the underlying controller class. Feel free to correct me if that approach isn't suitable