### PR TITLE
[API] Add missing ms:del documentation title

### DIFF
--- a/src/api/1/controller-memory-storage/del/index.md
+++ b/src/api/1/controller-memory-storage/del/index.md
@@ -4,6 +4,8 @@ algolia: true
 title: del
 ---
 
+# del
+
 {{{since "1.0.0"}}}
 
 Deletes a list of keys.


### PR DESCRIPTION
# Description

Add the missing `# del` title at the beginning of the [ms:del](https://docs-v2.kuzzle.io/api/1/controller-memory-storage/del/) documentation