### PR TITLE
[kuttlefish] Fix language icons path

### DIFF
--- a/.ci/comment.html
+++ b/.ci/comment.html
@@ -9,7 +9,7 @@
       <td align="center">
         <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/js/6"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
+        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.svg"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v6</em></td>
@@ -29,7 +29,7 @@
       <td align="center">
         <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/js/5"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
+        "https://docs-v2.kuzzle.io/assets/images/logos/javascript.svg"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v5</em></td>
@@ -49,7 +49,7 @@
       <td align="center">
         <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/go/1"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/go.png"
+        "https://docs-v2.kuzzle.io/assets/images/logos/go.svg"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>
@@ -69,7 +69,7 @@
       <td align="center">
         <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/java/1"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/java.png"
+        "https://docs-v2.kuzzle.io/assets/images/logos/java.svg"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>
@@ -89,7 +89,7 @@
       <td align="center">
         <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/cpp/1"
         style="font-size:0;"><img src=
-        "https://docs-v2.kuzzle.io/assets/images/logos/cpp.png"
+        "https://docs-v2.kuzzle.io/assets/images/logos/cpp.svg"
         width="32" height="32"></a>
       </td>
       <td align="center"><em>v1</em></td>


### PR DESCRIPTION
## What does this PR do?
Fix language icons path for Kuttlefish comment template.

### How should this be manually tested?
Since report process is little bit broken you can test template by:
* Pulling that branch
* Open `.ci/comment_pr.html` with a markdown previewer or a Web browser.

You should see new language icons made by @etrousset and @Njuelle 