### PR TITLE
[kzl-852] Document.count body is optional

### DIFF
--- a/src/api/1/controller-document/count/index.md
+++ b/src/api/1/controller-document/count/index.md
@@ -64,8 +64,6 @@ Body:
 
 ## Body properties
 
-A body must be provided to `count` queries. It can be left empty: in that case, the `count` query returns the total number of documents in a data collection.
-
 ### Optional:
 
 * `query`: if provided, will count only documents matching this search query. Uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl.html) syntax.


### PR DESCRIPTION
**:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1214**

## What does this PR do?

Following https://github.com/kuzzleio/kuzzle/pull/1214, reverts the change applied in https://github.com/kuzzleio/documentation-V2/pull/110
