### PR TITLE
SDK snippets: add the ability to test multiple outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can test the snippets locally by using the script `run-snippet-tests.sh`.
 This script looks recursively for snippets to test, using the path provided as an argument.
 You must at least have a sdk language and version in the provided path: `src/sdk-reference/<language>/<version>[/path/to/snippets]`
 
-First, you have to run a Kuzzle stack with the following script: `bash .travis/start_kuzzle.sh`
+First, you have to run a Kuzzle stack with the following script: `bash .ci/start_kuzzle.sh`
 
 Then you can run snippets for any language:
 

--- a/test/lib/helpers/logger.js
+++ b/test/lib/helpers/logger.js
@@ -85,8 +85,8 @@ class Logger {
           console.log(red('        EXPECTED:'), result.expected || snippet.expected);
           console.log(red('        GOT     :'), result.actual);
         } else if (result.code === 'ERR_ORDER') {
-          console.log(red('        THIS RESULT: '), result.after);
-          console.log(red('        CAME BEFORE: '), result.before);
+          console.log(red('        THIS RESULT: '), result.actualOrder[0]);
+          console.log(red('        CAME BEFORE: '), result.actualOrder[1]);
         } else {
           console.log(red('        ERROR   :'), result.actual);
         }

--- a/test/lib/helpers/logger.js
+++ b/test/lib/helpers/logger.js
@@ -82,11 +82,16 @@ class Logger {
         console.log(red('        CODE    :'), result.code);
         console.log(red('        FILE    :'), result.file);
         if (result.code === 'ERR_ASSERTION') {
-          console.log(red('        EXPECTED:'), snippet.expected);
+          console.log(red('        EXPECTED:'), result.expected || snippet.expected);
           console.log(red('        GOT     :'), result.actual);
+        } else if (result.code === 'ERR_ORDER') {
+          console.log(red('        THIS RESULT: '), result.after);
+          console.log(red('        CAME BEFORE: '), result.before);
         } else {
           console.log(red('        ERROR   :'), result.actual);
         }
+
+
         console.log(
           blue(`[${snippet.language}] `),
           'You can run the snippet locally with the following command:'

--- a/test/lib/runners/baseRunner.js
+++ b/test/lib/runners/baseRunner.js
@@ -40,7 +40,6 @@ module.exports = class BaseRunner {
   }
 
   async runExpect(snippet) {
-    // const expectedRegexp = new RegExp(snippet.expected);
     return new Promise((resolve, reject) => {
       nexpect
         .spawn(this.nexpectCommand, { stream: 'all' })
@@ -77,8 +76,7 @@ module.exports = class BaseRunner {
             if (match.index < lastIndex) {
               return reject(new TestResult({
                 code: 'ERR_ORDER',
-                before: e,
-                after: previous
+                actualOrder: [previous, e]
               }));
             }
 

--- a/test/lib/runners/baseRunner.js
+++ b/test/lib/runners/baseRunner.js
@@ -55,7 +55,6 @@ module.exports = class BaseRunner {
           }
 
           const
-            output = stdout.join('\n'),
             expected = Array.isArray(snippet.expected) ? snippet.expected : [snippet.expected];
 
           let
@@ -63,7 +62,11 @@ module.exports = class BaseRunner {
             previous = null;
 
           for (const e of expected) {
-            const match = output.match(e);
+            let match = null;
+
+            for (let i = 0; i < stdout.length && match === null; i++) {
+              match = stdout[i].match(e);
+            }
 
             if (match === null) {
               return reject(new TestResult({


### PR DESCRIPTION
# Description

To make examples clearer, or because of rich outputs, there are code snippets that need to output multiple lines of information.

This PR adds the possibility to the current system to test outputs on multiple lines. To make it work, just use the YAML format for multiple values.

For instance, here is a snippet on another branch (currently under development):

```js
try {
  await kuzzle.ms.set('key', 'foobar');

  // Prints: 26
  console.log(await kuzzle.ms.bitcount('key'));

  // Prints: 4
  console.log(await kuzzle.ms.bitcount('key', {start: 0, end: 0}));
} catch (error) {
  console.error(error.message);
}
```

As the snippet states, there are 2 outputs.

This snippet can now be tested using the following syntax:

```yaml
expected:
  - 26
  - 4
```

Also, if there are multiple outputs, then the code in this PR also checks that the order is respected.

For instance, if we invert the example above:

```yaml
expected:
  - 4
  - 26
```

The following error is thrown:

```
[js]  ✗ msbitcount: Counts the number of set bits (population counting) in a string
        CODE    : ERR_ORDER
        FILE    : sdk-reference/js/6/ms/bitcount/snippets/bitcount.js
        THIS RESULT:  4
        CAME BEFORE:  26
[js]  You can run the snippet locally with the following command:
[js]  node test/bin/msbitcount.js

```