### PR TITLE
[kuttlefish] Use dl.kuzzle.io to store reports

### DIFF
--- a/.ci/comment.html
+++ b/.ci/comment.html
@@ -7,7 +7,7 @@
     </tr>
     <tr>
       <td align="center">
-        <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/js/6"
+        <a href="https://dl.kuzzle.io/reports/{{.prId}}/js/6/report.html"
         style="font-size:0;"><img src=
         "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
         width="32" height="32"></a>
@@ -27,7 +27,7 @@
     </tr>
         <tr>
       <td align="center">
-        <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/js/5"
+        <a href="https://dl.kuzzle.io/reports/{{.prId}}/js/5/report.html"
         style="font-size:0;"><img src=
         "https://docs-v2.kuzzle.io/assets/images/logos/javascript.png"
         width="32" height="32"></a>
@@ -47,7 +47,7 @@
     </tr>
     <tr>
       <td align="center">
-        <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/go/1"
+        <a href="https://dl.kuzzle.io/reports/{{.prId}}/go/1/report.html"
         style="font-size:0;"><img src=
         "https://docs-v2.kuzzle.io/assets/images/logos/go.png"
         width="32" height="32"></a>
@@ -67,7 +67,7 @@
     </tr>
     <tr>
       <td align="center">
-        <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/java/1"
+        <a href="https://dl.kuzzle.io/reports/{{.prId}}/java/1/report.html"
         style="font-size:0;"><img src=
         "https://docs-v2.kuzzle.io/assets/images/logos/java.png"
         width="32" height="32"></a>
@@ -87,7 +87,7 @@
     </tr>
     <tr>
       <td align="center">
-        <a href="https://docs-v2.kuzzle.io/reports/{{.prId}}/cpp/1"
+        <a href="https://dl.kuzzle.io/reports/{{.prId}}/cpp/1/report.html"
         style="font-size:0;"><img src=
         "https://docs-v2.kuzzle.io/assets/images/logos/cpp.png"
         width="32" height="32"></a>

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
   - AWS_S3_BUCKET=docs-v2.kuzzle.io
   - TRAVIS_S3_BUCKET=travis-cache.kuzzle.io
+  - REPORT_S3=dl.kuzzle.io
   - AWS_CLOUDFRONT_DISTRIBUTION_ID=E23K3OMU0671PL
   - secure: e2j8CdD86voR0FKnDzo0BYIysfDjAdUW6FfO42VSaLPV97DjKdJd5dlhtDq+0U2/ae1iL3YpLlbVKr+wveS21hl15+jG+8miShnScGn3bhwe6P11uLCs9JL/WfoJ0vHueLy3XWHE8R51Mu2lD5aFJxQBRExQ06zS4rjev/ZFiipRlLFsYFeKgZ7I0WKo6Aqqt9wP7SFfuvr5jNLwgDIMvi9rWP+ZlbZIzm7of7QAzJfBK17VwszCatBlREWzXTGgxnVK09fJJdCZ9gTWwrayXxif+DVFCkCuKgG12glh1R3k5EBu7IkJsqCdTWYJ5AC2OBaMOvwpE3d340j0xvnDtmVUArDPJohQiBN6GTOo8R54AKbOE25U1YKSPqZ7pJplsvRjkpdlCnGVXmR+W/2HdWK6uSXyg/iYncb4DVVPnqk/WfQzKtha5ClZRXUUNUTaY+4wm8+2rqFnIa9IMKNgHnvPmLyf/J6K1ooPJHYB4HfvS/4cP0DXQTe3q9U06HeWGOiS32Jq86QRo2Zm7yUVmYu0fEU/jQIJtv3BGuzz8aeF5JGFcKOe11sETHjs7CKrK89hEtKkpmuw3V7FteWfxla8YNkhQBLqeY+z3Cq7k77DVXdupzQZwGeYBNjHECnS38PBQ35biZhZTEM0/uY9NITiQpbdga+njAK2SqHRtiw=
   - secure: CEIMGeEcS+zpdiRXAripOJxwUg5rbmO8pe4u+zm5eteoLA6idQNUEi4o2F2pyWFNZy95B3BiM3ZSMStwdJwu3tZ4cjmX3XnU5GN26tw4wYsM2bW3iNH5xi1pxjtyFTwT9h6JL+mMxOBbPK8DmOPSWEWVMkAs+bw1GLOOMHQ3q29qXUwEDrb4+SS8mAXlWmQSFT+lQVGtRbvu38F6m24qSFQVL2mB/VKty3meByvkddaKShTrhsk867eR1pAvBBjtQHiyVCGaKHHspeOsWjfnnIr2I5CEWFlHSCOQgtY7obS5G0LmNcoApc/aAEYUWcSZ1TIoY0KtK+LyTkKNzB1oaqbVt0ZlrPJUt7fXSlBKyM/UbZ8NFCsIJ+Yi/dXUrD99cPONJK4sVBO9YLmZEpVWfGd1NJs6isULZJoqqbNb9XQ59uZpR9jo9ZyR7IUsHcshQAN8mH0EJLbRtiAN9m3bA89DkdEMWph9UmwBtKYC52JHne6ENClMAk7K/IgzB20iYd4B8M5a6k43DpDUaNf6gjkhL6RrR0ssiNJsI3QmdcYodf2mDlJuYnVmaHpb8dcUBC8ImcVjYKuDst32RXvkAYKvpCy67A2FDuZ1F2CE+hbA7fIaYsN5UkkcF6nYcNJMZ6PF76WQ+2j2UgLVGOvAl91lpoo1P07fzM4P5j9bnc0=
@@ -26,7 +27,7 @@ install:
 
 stages:
   - name: Build
-  - name: Snippets tests
+  - name: Tests
   - name: Deployment
     if: type != pull_request AND branch = master
 
@@ -79,7 +80,7 @@ jobs:
       after_script:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            aws s3 cp reports/ s3://$AWS_S3_BUCKET/reports/$TRAVIS_PULL_REQUEST/js/5/ --recursive --exclude "*.gitkeep"
+            mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/js/5/ --recursive --exclude "*.gitkeep"
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
             cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
@@ -103,7 +104,7 @@ jobs:
       after_script:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            aws s3 cp reports/ s3://$AWS_S3_BUCKET/reports/$TRAVIS_PULL_REQUEST/js/6/ --recursive --exclude "*.gitkeep"
+            mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/js/6/ --recursive --exclude "*.gitkeep"
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
             cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
@@ -127,7 +128,7 @@ jobs:
       after_script:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            aws s3 cp reports/ s3://$AWS_S3_BUCKET/reports/$TRAVIS_PULL_REQUEST/go/1/ --recursive --exclude "*.gitkeep"
+            mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/go/1/ --recursive --exclude "*.gitkeep"
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
             cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
@@ -151,7 +152,7 @@ jobs:
       after_script:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            aws s3 cp reports/ s3://$AWS_S3_BUCKET/reports/$TRAVIS_PULL_REQUEST/java/1/ --recursive --exclude "*.gitkeep"
+            mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/java/1/ --recursive --exclude "*.gitkeep"
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
             cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh
@@ -175,7 +176,7 @@ jobs:
       after_script:
         - |
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            aws s3 cp reports/ s3://$AWS_S3_BUCKET/reports/$TRAVIS_PULL_REQUEST/cpp/1/ --recursive --exclude "*.gitkeep"
+            mv reports/index.html reports/report.html && aws s3 cp reports/ s3://$REPORT_S3/reports/$TRAVIS_PULL_REQUEST/cpp/1/ --recursive --exclude "*.gitkeep"
             cd .ci && aws s3 cp . s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER --recursive --exclude "*.sh" --exclude "*.html" --exclude "*.yml" --exclude ".gitignore" && cd -
             cd .ci && aws s3 sync s3://$TRAVIS_S3_BUCKET/documentation-v2/$TRAVIS_BUILD_NUMBER . && cd -
             bash ./.ci/comment_pr.sh


### PR DESCRIPTION

## What does this PR do?
Because we flush docs-v2.kuzzle.io when deploying.
It is not a safe place for snippets reports anymore.

### Other changes
Fix travis build stages order.