### PR TITLE
[build] Add algolia metas automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ if (options.algolia.privateKey) {
     // the last child in the tree structure
     .use((files, ms, done) => {
       for (const file of Object.values(files)) {
-        if (file.ancestry) { // only content page (.md) has ancestry object
+        if (file.ancestry) { // only content pages (.md) have ancestry object
           const lastChildren = ancestryHelpers.getLastChildren(file);
           if (lastChildren.path === file.path) {
             file.algolia = true;

--- a/index.js
+++ b/index.js
@@ -253,6 +253,18 @@ metalsmith
 if (options.algolia.privateKey) {
   log('Algolia indexing enabled');
   metalsmith
+    //Add algolia metas automatically only if needed
+    .use((files, ms, done) => {
+      for (const file of Object.values(files)) {
+        if (file.ancestry) {
+          const lastChildren = ancestryHelpers.getLastChildren(file);
+          if (lastChildren.path === file.path) {
+            file.algolia = true;
+          }
+        }
+      }
+      setImmediate(done);
+    })
     .use(algolia({
       clearIndex: true,
       projectId: options.algolia.projectId,

--- a/index.js
+++ b/index.js
@@ -253,10 +253,11 @@ metalsmith
 if (options.algolia.privateKey) {
   log('Algolia indexing enabled');
   metalsmith
-    //Add algolia metas automatically only if needed
+    // Add algolia metas automatically only on
+    // the last child in the tree structure
     .use((files, ms, done) => {
       for (const file of Object.values(files)) {
-        if (file.ancestry) {
+        if (file.ancestry) { // only content page (.md) has ancestry object
           const lastChildren = ancestryHelpers.getLastChildren(file);
           if (lastChildren.path === file.path) {
             file.algolia = true;

--- a/index.js
+++ b/index.js
@@ -254,7 +254,7 @@ if (options.algolia.privateKey) {
   log('Algolia indexing enabled');
   metalsmith
     // Add algolia metas automatically only on
-    // the last child in the tree structure
+    // the last children of the tree structure (Leaf of the arborescence)
     .use((files, ms, done) => {
       for (const file of Object.values(files)) {
         if (file.ancestry) { // only content pages (.md) have ancestry object


### PR DESCRIPTION
## What does this PR do?
Add algolia metas automatically only if page is the last children in ancestry (only for build process of course).
Moreover it allows us to optimize the number of requests to algolia
