### PR TITLE
Update the getMyRights C++ snippet to the new C++ SDK version

### DIFF
--- a/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
@@ -1,8 +1,7 @@
 try {
   kuzzle->auth->login("local", "{\"username\":\"foo\",\"password\":\"bar\"}");
-  std::vector<kuzzleio::user_right*> rights = kuzzle->auth->getMyRights();
-
-  for (int i = 0; rights[i]; i++) {
+  std::vector<std::unique_ptr<kuzzleio::UserRight>> rights = kuzzle->auth->getMyRights();
+  for (int i = 0; i < rights.size(); i++) {
     std::cout << rights[i]->controller << " " << rights[i]->action << std::endl;
     std::cout << rights[i]->index << " " << rights[i]->collection << std::endl;
     std::cout << rights[i]->value << std::endl;


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-cpp/pull/42 :warning: 

# Description

Since the last C++ SDK update, the `user_rights*` structure created in the C++ SDK by the `auth:getMyRight` API call is now correctly freed. 
This cause another problem, since a vector is returned by that method, referencing pointers from the now deallocated structure. This dangling pointers problem causes random crashes whenever one tries to access the value returned by `auth:getMyRight`, as done in the C++ code example for that API method.

This problem has been resolved in this PR: https://github.com/kuzzleio/sdk-cpp/pull/42

This documentation PR updates the C++ example, as the type of the value returned by `auth:getMyRight` has changed.