### PR TITLE
Update snippets to the latest C++ SDK version

### DIFF
--- a/src/sdk-reference/cpp/1/auth/get-current-user/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-current-user/index.md
@@ -8,22 +8,15 @@ description: Returns the profile object for the user linked to the `JSON Web Tok
 
 Returns the profile object for the user linked to the `JSON Web Token`, provided in the query or the `Authorization` header.
 
-## Signature
+## Arguments
 
 ```cpp
-kuzzle_user* getCurrentUser();
+User getCurrentUser();
 ```
 
 ## Return
 
-A pointer to a kuzzle_user object containing:
-
-| Property     | Type    | Description                       |
-| ---------- | ------- | --------------------------------- |
-| `id` | const char* | The user ID |
-| `content` | const char* | The user content |
-| `profile_ids` | char** | An array containing the profile ids |
-| `profile_ids_length` | size_t | The size of the profile_ids array |
+A [User]({{ site_base_path }}sdk-reference/cpp/1/user/) object.
 
 ## Exceptions
 

--- a/src/sdk-reference/cpp/1/auth/get-current-user/snippets/get-current-user.cpp
+++ b/src/sdk-reference/cpp/1/auth/get-current-user/snippets/get-current-user.cpp
@@ -1,6 +1,6 @@
 try {
   kuzzle->auth->login("local", "{\"username\":\"foo\",\"password\":\"bar\"}");
-  kuzzleio::kuzzle_user* user = kuzzle->auth->getCurrentUser();
+  kuzzleio::User user = kuzzle->auth->getCurrentUser();
 
   std::cout << "Success" << std::endl;
 } catch (kuzzleio::KuzzleException &e) {

--- a/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
@@ -8,37 +8,30 @@ description: Returns the rights for the user linked to the `JSON Web Token`.
 
 Returns the rights for the user linked to the `JSON Web Token`, provided in the query or the `Authorization` header.
 
-## Signature
-
-```cpp
-std::vector<std::unique_ptr<UserRight>> getMyRights(query_options *options=nullptr);
-```
-
 ## Arguments
 
-| Arguments    | Type    | Description | Required
-|--------------|---------|-------------|----------
-| `options`  | query_options*    | A pointer to a `kuzzleio::query_options` containing query options | no
+```cpp
+std::vector<std::unique_ptr<UserRight>> 
+  getMyRights(query_options *options=nullptr);
+```
 
-### **Options**
+<br/>
 
-Additional query options
+| Arguments    | Type    | Description |
+|--------------|---------|-------------|
+| `options`  | <pre>kuzzleio::query_options*</pre>  | Optional query options |
 
-| Property     | Type    | Description                       | Default
-| ---------- | ------- | --------------------------------- | -------
-| `queuable` | bool | Make this request queuable or not | `true`
+### options
+
+Additional query options:
+
+| Property     | Type    | Description  |
+| ---------- | ------- | -------------- |
+| `queuable` | <pre>bool (true)</pre> | If true, queues the request during downtime, until connected to Kuzzle again |
 
 ## Return
 
-A std::vector of `user_right*`. The `user_right` structure contain:
-
-| Property     | Type    | Description                       |
-| ---------- | ------- | --------------------------------- |
-| `controller` | const char* | Controller on wich the rights are applied |
-| `action` | const char* | Action on wich the rights are applied |
-| `index` | const char* | Index on wich the rights are applied |
-| `collection` | const char* | Collection on wich the rights are applied |
-| `value` | const char* | Rights (`allowed|denied|conditional`) |
+A [UserRight]({{ site_base_path }}sdk-reference/cpp/1/user-right/) object.
 
 ## Exceptions
 

--- a/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/index.md
@@ -11,7 +11,7 @@ Returns the rights for the user linked to the `JSON Web Token`, provided in the 
 ## Signature
 
 ```cpp
-std::vector<user_right*> getMyRights(query_options *options=nullptr);
+std::vector<std::unique_ptr<UserRight>> getMyRights(query_options *options=nullptr);
 ```
 
 ## Arguments

--- a/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
@@ -1,6 +1,9 @@
 try {
   kuzzle->auth->login("local", "{\"username\":\"foo\",\"password\":\"bar\"}");
-  std::vector<std::unique_ptr<kuzzleio::UserRight>> rights = kuzzle->auth->getMyRights();
+
+  std::vector<std::unique_ptr<kuzzleio::UserRight>> rights =
+    kuzzle->auth->getMyRights();
+
   for (int i = 0; i < rights.size(); i++) {
     std::cout << rights[i]->controller << " " << rights[i]->action << std::endl;
     std::cout << rights[i]->index << " " << rights[i]->collection << std::endl;

--- a/src/sdk-reference/cpp/1/auth/update-self/index.md
+++ b/src/sdk-reference/cpp/1/auth/update-self/index.md
@@ -15,18 +15,18 @@ User updateSelf(const std::string& content, query_options* options=nullptr);
 ```
 
 | Arguments    | Type    | Description
-|--------------|---------|-------------
-| `content` | const std::string& | the new credentials
-| `options`  | query_options*    | A pointer to a `kuzzleio::query_options` containing query options
+|--------------|---------|-------------|
+| `content` | <pre>const std::string&</pre> | New credentials |
+| `options`  | <pre>kuzzleio::query_options*</pre>  | Optional query options |
 
 
 ### **Options**
 
-Additional query options
+Additional query options:
 
-| Property     | Type    | Description                       | Default |
-| ---------- | ------- | --------------------------------- | ------- |
-| `queuable` | boolean | Make this request queuable or not | `true`  |
+| Property     | Type    | Description  |
+| ---------- | ------- | -------------- |
+| `queuable` | <pre>bool (true)</pre> | If true, queues the request during downtime, until connected to Kuzzle again |
 
 ## Return
 

--- a/src/sdk-reference/cpp/1/auth/update-self/index.md
+++ b/src/sdk-reference/cpp/1/auth/update-self/index.md
@@ -8,13 +8,11 @@ description: Updates the current user object in Kuzzle.
 
 Updates the current user object in Kuzzle.
 
-## Signature
+## Arguments
 
 ```cpp
-kuzzle_user* updateSelf(const std::string& content, query_options* options=nullptr);
+User updateSelf(const std::string& content, query_options* options=nullptr);
 ```
-
-## Arguments
 
 | Arguments    | Type    | Description
 |--------------|---------|-------------
@@ -38,7 +36,7 @@ Throws a `kuzzleio::KuzzleException` if there is an error. See how to [handle er
 
 ## Return
 
-A pointer to a kuzzle_user.
+A [User]({{ site_base_path }}sdk-reference/cpp/1/user/) object.
 
 ## Usage
 

--- a/src/sdk-reference/cpp/1/auth/update-self/index.md
+++ b/src/sdk-reference/cpp/1/auth/update-self/index.md
@@ -28,15 +28,13 @@ Additional query options
 | ---------- | ------- | --------------------------------- | ------- |
 | `queuable` | boolean | Make this request queuable or not | `true`  |
 
+## Return
+
+A [User]({{ site_base_path }}sdk-reference/cpp/1/user/) object.
 
 ## Exceptions
 
 Throws a `kuzzleio::KuzzleException` if there is an error. See how to [handle error]({{ site_base_path }}sdk-reference/cpp/1/essentials/error-handling).
-
-
-## Return
-
-A [User]({{ site_base_path }}sdk-reference/cpp/1/user/) object.
 
 ## Usage
 

--- a/src/sdk-reference/cpp/1/auth/update-self/snippets/update-self.cpp
+++ b/src/sdk-reference/cpp/1/auth/update-self/snippets/update-self.cpp
@@ -1,8 +1,9 @@
 try {
   kuzzle->auth->login("local", "{\"username\":\"foo\",\"password\":\"bar\"}");
-  kuzzle->auth->updateSelf("{\"foo\":\"bar\"}");
+  User updatedUser = kuzzle->auth->updateSelf("{\"foo\":\"bar\"}");
 
-  std::cout << "Success" << std::endl;
+  // Prints: {"foo":"bar","profileIds":["default"]}
+  std::cout << updatedUser.content() << std::endl;
 } catch (kuzzleio::KuzzleException &e) {
   std::cerr << e.getMessage() << std::endl;
 }

--- a/src/sdk-reference/cpp/1/auth/update-self/snippets/update-self.test.yml
+++ b/src/sdk-reference/cpp/1/auth/update-self/snippets/update-self.test.yml
@@ -4,7 +4,6 @@ hooks:
   before: curl -X POST kuzzle:7512/users/foo/_create -H "Content-Type:application/json" --data '{"content":{"profileIds":["default"]},"credentials":{"local":{"username":"foo","password":"bar"}}}'
   after: curl -X DELETE kuzzle:7512/users/foo
 template: default
-expected: Success
-
+expected: "\"foo\"\\:\"bar\""
 sdk: cpp
 version: 1

--- a/src/sdk-reference/cpp/1/search-result/index.md
+++ b/src/sdk-reference/cpp/1/search-result/index.md
@@ -2,7 +2,7 @@
 layout: sdk.html.hbs
 title: SearchResult
 description: How to deal with Kuzzle search results
-order: 500
+order: 400
 ---
 # SearchResult
 

--- a/src/sdk-reference/cpp/1/user-right/index.md
+++ b/src/sdk-reference/cpp/1/user-right/index.md
@@ -1,0 +1,22 @@
+---
+layout: sdk.html.hbs
+title: UserRight
+description: UserRight object documentation
+order: 400
+---
+
+# UserRight
+
+The `UserRight` class is the SDK representation of a single [user's right](https://docs-v2.kuzzle.io/guide/1/essentials/user-authentication/#creating-users-default).
+
+Instances of the `UserRight` class are returned by methods such as [auth:getMyRights]({{ site_base_path }}sdk-reference/cpp/1/auth/get-my-rights).
+
+## Properties
+
+| Property | Type | Description |
+|--- |--- |--- |
+| `action` | <pre>const std::string</pre> | Action on wich the rights are applied |
+| `collection` | <pre>const std::string</pre> | Collection on wich the rights are applied |
+| `controller` | <pre>const std::string</pre> | Controller on wich the rights are applied |
+| `index` | <pre>const std::string</pre> | Index on wich the rights are applied |
+| `value` | <pre>const std::string</pre> | Right status.<br/>Possible values: `allowed`, `denied`, `conditional` |

--- a/src/sdk-reference/cpp/1/user/content/index.md
+++ b/src/sdk-reference/cpp/1/user/content/index.md
@@ -1,0 +1,20 @@
+---
+layout: sdk.html.hbs
+title: content
+description: Getter for the _content property
+---
+
+# content
+
+Returns the user's content.
+
+## Arguments
+
+```cpp
+std::string const& content() const;
+```
+
+## Return
+
+The `content` getter returns the user's content.
+

--- a/src/sdk-reference/cpp/1/user/id/index.md
+++ b/src/sdk-reference/cpp/1/user/id/index.md
@@ -1,0 +1,19 @@
+---
+layout: sdk.html.hbs
+title: id
+description: Getter for the _id property
+---
+
+# id
+
+Returns the user's unique identifier (or [kuid]({{ site_base_path }}guide/1/essentials/user-authentication/#kuzzle-user-identifier-kuid-default)).
+
+## Arguments
+
+```cpp
+std::string const& id() const;
+```
+
+## Return
+
+The `id` getter returns the user's kuid.

--- a/src/sdk-reference/cpp/1/user/index.md
+++ b/src/sdk-reference/cpp/1/user/index.md
@@ -2,5 +2,5 @@
 layout: sdk.html.hbs
 title: User
 description: User object documentation
-order: 600
+order: 400
 ---

--- a/src/sdk-reference/cpp/1/user/index.md
+++ b/src/sdk-reference/cpp/1/user/index.md
@@ -1,0 +1,6 @@
+---
+layout: sdk.html.hbs
+title: User
+description: User object documentation
+order: 600
+---

--- a/src/sdk-reference/cpp/1/user/intro/index.md
+++ b/src/sdk-reference/cpp/1/user/intro/index.md
@@ -1,0 +1,12 @@
+---
+layout: sdk.html.hbs
+title: Introduction
+description: Kuzzle User representation
+order: 0
+---
+
+# Introduction
+
+The `User` class is the SDK representation of a Kuzzle [user](https://docs-v2.kuzzle.io/guide/1/essentials/user-authentication/#creating-users-default).
+
+Instances of the `User` class are returned by methods such as [auth:getCurrentUser]({{ site_base_path }}sdk-reference/cpp/1/auth/get-current-user).

--- a/src/sdk-reference/cpp/1/user/profile_ids/index.md
+++ b/src/sdk-reference/cpp/1/user/profile_ids/index.md
@@ -1,0 +1,19 @@
+---
+layout: sdk.html.hbs
+title: profile_ids
+description: Getter for the _profile_ids property
+---
+
+# profile_ids
+
+Returns the list of profile identifiers attached to this user.
+
+## Arguments
+
+```cpp
+std::vector<std::string> const& profile_ids() const;
+```
+
+## Return
+
+The `profile_ids` getter returns a list of profile identifiers.

--- a/src/sdk-reference/cpp/1/websocket/index.md
+++ b/src/sdk-reference/cpp/1/websocket/index.md
@@ -2,5 +2,5 @@
 layout: sdk.html.hbs
 title: WebSocket
 description: WebSocket object documentation
-order: 700
+order: 400
 ---


### PR DESCRIPTION
# Description

The latest C++ experimental release introduced a few breaking changes in the `auth` methods signatures.

The following documentations and their corresponding code snippets have been updated:
* `auth:getCurrentUser` does not return a `kuzzle_user*` pointer anymore, but a `User` class instance
* `auth:getMyRights` now returns a vector of `std::unique_ptr<UserRight>` pointers
* `auth:updateSelf` now return a `User` class instance instead of a `kuzzle_user*` pointer

The following core classes have been added to the documentation:
* `User`
* `UserRight`

# Other changes

* The changed methods have had their documentation updated to the latest documentation format.
* All core classes documentations now share the same order number, to let the doc builder sort these sections alphabetically in the separator