### PR TITLE
[C++ SDK] update the auth:getMyRight return type

### DIFF
--- a/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
+++ b/src/sdk-reference/cpp/1/auth/get-my-rights/snippets/get-my-rights.cpp
@@ -1,13 +1,13 @@
 try {
   kuzzle->auth->login("local", "{\"username\":\"foo\",\"password\":\"bar\"}");
 
-  std::vector<std::unique_ptr<kuzzleio::UserRight>> rights =
+  std::vector<std::shared_ptr<kuzzleio::UserRight>> rights =
     kuzzle->auth->getMyRights();
 
   for (int i = 0; i < rights.size(); i++) {
-    std::cout << rights[i]->controller << " " << rights[i]->action << std::endl;
-    std::cout << rights[i]->index << " " << rights[i]->collection << std::endl;
-    std::cout << rights[i]->value << std::endl;
+    std::cout << rights[i]->controller() << " " << rights[i]->action() << std::endl;
+    std::cout << rights[i]->index() << " " << rights[i]->collection() << std::endl;
+    std::cout << rights[i]->value() << std::endl;
   }
 } catch (kuzzleio::KuzzleException &e) {
   std::cerr << e.getMessage() << std::endl;


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-cpp/pull/46 (the CI *will fail* until the dependency is merged and the SDK deployed)

# Description

https://github.com/kuzzleio/sdk-cpp/pull/46 changes the return type of `auth:getMyRight` for the C++ SDK. 
This PR update the corresponding code snippet to match that change.