### PR TITLE
Fix the documentation rebuild time in development mode

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -22,7 +22,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        exclude: [/\app.js$/, /\prism.js$/, /node_modules/],
+        exclude: [/app\.js$/, /prism\.js$/, /node_modules/],
         loader: 'babel-loader',
         query: {
           presets: ['@babel/preset-env']
@@ -31,4 +31,4 @@ module.exports = {
     ]
   },
   devtool: 'source-map'
-}
+};

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -1,34 +1,42 @@
-const webpack = require('webpack');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const path = require('path');
+const
+  webpack = require('webpack'),
+  UglifyJsPlugin = require('uglifyjs-webpack-plugin'),
+  path = require('path');
 
-module.exports = {
-  context: path.resolve(__dirname, '../src/assets/js/'),
-  entry: './main.js',
-  output: {
-    path: path.resolve(__dirname, '../build/assets/js'),
-    filename: 'bundle.min.js'
-  },
-  plugins: [
+module.exports = (opts) => {
+  const plugins = [
     new webpack.ProvidePlugin({
       $: 'jquery',
       jQuery: 'jquery',
       algoliasearch: 'algoliasearch',
       select2: 'select2'
-    }),
-    new UglifyJsPlugin({sourceMap: true}),
-  ],
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        exclude: [/app\.js$/, /prism\.js$/, /node_modules/],
-        loader: 'babel-loader',
-        query: {
-          presets: ['@babel/preset-env']
+    })
+  ];
+
+  if (! opts.dev.enabled) {
+    plugins.push(new UglifyJsPlugin({sourceMap: true}));
+  }
+
+  return {
+    plugins,
+    context: path.resolve(__dirname, '../src/assets/js/'),
+    entry: './main.js',
+    output: {
+      path: path.resolve(__dirname, '../build/assets/js'),
+      filename: 'bundle.min.js'
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          exclude: [/app\.js$/, /prism\.js$/, /node_modules/],
+          loader: 'babel-loader',
+          query: {
+            presets: ['@babel/preset-env']
+          }
         }
-      }
-    ]
-  },
-  devtool: 'source-map'
+      ]
+    },
+    devtool: 'source-map'
+  };
 };

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ let filesSave = null;
 
 // configuration
 const msDefaultOpts = require('./config/metalsmith');
+const webpackConfig = require('./config/webpack');
 const sdkVersions = JSON.stringify(ymlRead.sync(path.join(__dirname, './test/sdk-versions.yml'))).replace(/\s+/g, '');
 
 // arguments
@@ -67,7 +68,7 @@ const ignored = [
   '**/**/page.java.md',
   '**/templates/*',
   // with webpack, it is no longer necessary to copy js files in build folder
-  '**/**/assets/js/*' 
+  '**/**/assets/js/*'
 ];
 
 if (!options.dev.enabled) {
@@ -180,12 +181,12 @@ metalsmith
     }
     setImmediate(done);
   })
-  .use(metalsmithWebpack(require('./config/webpack.js')))
+  .use(metalsmithWebpack(webpackConfig(options)))
   .use(permalinks({relative: false}));
 
 metalsmith
   .use((files, ms, done) => {
-    // automatically add redirection to the last children if the current file 
+    // automatically add redirection to the last children if the current file
     // isn't the last children (Leaf of the arborescence)
     for (const file of Object.values(files)) {
       if (file.ancestry && ! file.noredirect) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node index.js --gzip",
     "dev": "node index.js --dev --watch",
-    "lint": "eslint --max-warnings=0 *.js ./test/lib ./test/test ./helpers ./scaffolding/lib ./plugins",
+    "lint": "eslint --max-warnings=0 *.js ./test/lib ./test/test ./helpers ./scaffolding/lib ./plugins ./config",
     "snippets-testing": "bash run-all-snippet-tests.sh",
     "unit-testing": "mocha ./test/test",
     "scaffold": "node scaffolding/index.js",


### PR DESCRIPTION
# Description

Since the Javascript bundling has been moved to webpack, documentation rebuilds were very slow.
This is due to the uglifier plugin, which is very useful in production to reduce the size of the bundle, but makes the documentation hot reload a burden in dev mode.

This PR deactives the uglifier plugin in dev mode. This reduce the rebuild time from 6-9s on my machine to 150-300ms.

# Other changes

Add the `./config` directory to the eslint scope, and fix the linter errors.