### PR TITLE
Fixed `body` in searchUsers API example

### DIFF
--- a/src/api/1/controller-security/search-users/index.md
+++ b/src/api/1/controller-security/search-users/index.md
@@ -51,23 +51,25 @@ Body:
   "controller": "security",
   "action": "searchUsers",
   "body": {
-    "bool": {
-      "must": [
-        {
-          "in": {
-            "profileIds": ["anonymous", "default"]
-          }
-        },
-        {
-          "geo_distance": {
-            "distance": "10km",
-            "pos": {
-              "lat": "48.8566140",
-              "lon": "2.352222"
+    "query": {
+      "bool": {
+        "must": [
+          {
+            "in": {
+              "profileIds": ["anonymous", "default"]
+            }
+          },
+          {
+            "geo_distance": {
+              "distance": "10km",
+              "pos": {
+                "lat": "48.8566140",
+                "lon": "2.352222"
+              }
             }
           }
-        }
-      ]
+        ]
+      }
     }
   },
   // optional arguments


### PR DESCRIPTION
The `body` lacked of the `query` field