### PR TITLE
Pass function to hooks, pipes and actions

### DIFF
--- a/src/plugins/1/essentials/hooks/index.md
+++ b/src/plugins/1/essentials/hooks/index.md
@@ -14,12 +14,12 @@ Hooks can only listen: the received information cannot be changed. And Kuzzle do
 
 ## Usage
 
-Plugins can register hooks by exposing a `hooks` object: keys are listened [events]({{ site_base_path }}plugins/1/events), and values are either a function name to execute whenever that event is triggered, or an array of function names.
+Plugins can register hooks by exposing a `hooks` object: keys are listened [events]({{ site_base_path }}plugins/1/events), and values are either a function to execute whenever that event is triggered, or an array of functions.
 
 ```javascript
 this.hooks = {
-  '<kuzzle event to listen>': '<plugin function name to call>',
-  '<another event>': ['list', 'of', 'plugin', 'functions', 'to call']
+  '<kuzzle event to listen>': <function to call>,
+  '<another event>': [list, of, functions, to call]
 };
 ```
 
@@ -37,12 +37,12 @@ module.exports = class HookPlugin {
    */
   init (customConfig, context) {
     /*
-      Attaches the plugin function "myFunction" to the Kuzzle event
-      "document:afterCreate", triggered after a successful
+      Calls the plugin function "myFunction" when the Kuzzle event
+      "document:afterCreate" is triggered after a successful
       document creation
      */
     this.hooks = {
-      'document:afterCreate': 'myFunction'
+      'document:afterCreate': (...args) => this.myFunction(...args)
     };
   }
 

--- a/src/plugins/1/essentials/pipes/index.md
+++ b/src/plugins/1/essentials/pipes/index.md
@@ -20,12 +20,12 @@ Pipes can:
 
 ## Usage
 
-Plugins can register pipes by exposing a `pipes` object: keys are listened [events]({{ site_base_path }}plugins/1/events/), and values are either a function name to execute whenever that event is triggered, or an array of function names.
+Plugins can register pipes by exposing a `pipes` object: keys are listened [events]({{ site_base_path }}plugins/1/events/), and values are either a function to execute whenever that event is triggered, or an array of functions.
 
 ```javascript
 this.pipes = {
-  '<kuzzle event to listen>': '<plugin function name to call>',
-  '<another event>': ['list', 'of', 'plugin', 'functions', 'to call']
+  '<kuzzle event to listen>': <function to call>,
+  '<another event>': [list, of, functions, to call]
 };
 ```
 
@@ -58,7 +58,7 @@ module.exports = class PipePlugin {
       "document:afterGet"
      */
     this.pipes = {
-      'document:afterGet': 'restrictUser'
+      'document:afterGet': (...args) => this.restrictUser(...args)
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

Change the way we pass functions to plugins pipes, hooks and action.  
Now we pass functions instead of function name on the plugin object.

See https://github.com/kuzzleio/kuzzle/pull/1227

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :  
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
