### PR TITLE
Javascript SDK: websocket http headers option documentation

### DIFF
--- a/src/sdk-reference/js/6/websocket/constructor/index.md
+++ b/src/sdk-reference/js/6/websocket/constructor/index.md
@@ -7,15 +7,13 @@ order: 50
 
 # Constructor
 
-Use this constructor to create a new instance of the `WebSocket` protocol with specific options.  
+This constructor creates a new WebSocket connection, using the specified options.  
 
-## Signature
+## Arguments
 
 ```javascript
 WebSocket(host, [options]);
 ```
-
-## Arguments
 
 | Argument   | Type               | Description                           |
 | ---------- | ------------------ | ------------------------------------- |
@@ -28,10 +26,11 @@ WebSocket protocol connection options.
 
 | Property              | Type<br/>(default)  | Description   |
 | -------------- | --------- | ------------- |
-| `port`         | <pre>number</pre><br/>(`7512`) | Kuzzle server port               | 
-| `sslConnection`     | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server                    |   
 | `autoReconnect`     | <pre>boolean</pre><br/>(`true`) | Automatically reconnect to kuzzle after a `disconnected` event      | 
+| `port`         | <pre>number</pre><br/>(`7512`) | Kuzzle server port               | 
+| `headers` | <pre>object</pre>(`{}`) | Connection HTTP headers (e.g. origin, subprotocols, ...)<br/>**(Not supported by browsers)** |
 | `reconnectionDelay` | <pre>number</pre><br/>(`1000`) | Number of milliseconds between reconnection attempts               |  
+| `sslConnection`     | <pre>boolean</pre><br/>(`false`) | Use SSL to connect to Kuzzle server                    |   
 
 ## Return
 


### PR DESCRIPTION
# Description

Documents https://github.com/kuzzleio/sdk-javascript/pull/364

Also updates the websocket documentation page format to our latest standard, and sort the options list in alphabetical order.