### PR TITLE
[cleanup] Fix mispelled words, wrong instructions in getting started ...

### DIFF
--- a/src/api/1/controller-document/replace/index.md
+++ b/src/api/1/controller-document/replace/index.md
@@ -35,6 +35,8 @@ Body:
   "collection": "<collection>",
   "controller": "document",
   "action": "replace",
+  "_id": "<documentId>",
+  "refresh": "wait_for",
   "body": {
     // new document content
   }
@@ -80,7 +82,7 @@ Returns an object containing updated document information, with the following pr
   "requestId": "<unique request identifier>",
   "result": {
     "_id": "<documentId>",
-    "_source": { 
+    "_source": {
       // new document content
     },
     "_version": 13

--- a/src/sdk-reference/cpp/1/getting-started/index.md
+++ b/src/sdk-reference/cpp/1/getting-started/index.md
@@ -56,9 +56,10 @@ Create a `my-first-kuzzle-app.cpp` file and with the following source code :
 Build and run :
 
 ``` bash
-$ gcc -o my-first-kuzzle-app my-first-kuzzle-app.cpp -std=c++11 -lstdc++ -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread -Wl,-rpath=${KUZZLE_SDK_PATH}/lib
+$ g++ -o my-first-kuzzle-app my-first-kuzzle-app.cpp -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread -Wl,-rpath=${KUZZLE_SDK_PATH}/lib
 $ ./my-first-kuzzle-app
-Connected to Kuzzle Server
+Connected!
+Server current timestamp: 1549298495451
 ```
 
 ## Create data structure
@@ -72,20 +73,13 @@ Update `my-first-kuzzle-app.cpp` with the following content :
 Build and execute the program with the following commands :
 
 ``` sh
-$ gcc -o my-first-kuzzle-app my-first-kuzzle-app.cpp -std=c++11 -lstdc++ -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread -Wl,-rpath=${KUZZLE_SDK_PATH}/lib
-$ ./my-first-kuzzle-app
+$ g++ -o my-first-kuzzle-app my-first-kuzzle-app.cpp -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread
+$ LD_LIBRARY_PATH=${KUZZLE_SDK_PATH}/lib/ ./my-first-kuzzle-app
 Connected to Kuzzle Server
-Index 'nyc-open-data' and collection 'yellow-taxi' created
+Index nyc-open-data created!
+Collection yellow-taxi created!
 
 ```
-
-<!-- Congratulations, you performed a first connection to Kuzzle with a Go program.
-You are now able to:
-* Load the `Kuzzle Go SDK` from your `GOPATH` directory
-* Instantiate a protocol (here `websocket`) and a Kuzzle SDK instance
-* Connect to a Kuzzle instance running on `localhost`, with the WebSocket protocol
-* Create a data index
-* Create a data collection within an existing index -->
 
 ## Create your first document
 
@@ -105,22 +99,22 @@ Create a `create-document.cpp` file with the following source code :
 Build and run :
 
 ``` bash
-$ gcc -o create-document create-document.cpp -std=c++11 -lstdc++ -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread -Wl,-rpath=${KUZZLE_SDK_PATH}/lib
-$ ./create-document
+$ g++ -o create-document create-document.cpp -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread
+$ LD_LIBRARY_PATH=${KUZZLE_SDK_PATH}/lib/ ./create-document
 Connected to Kuzzle Server
 Document created successfuly
 {"_index":"nyc-open-data","_type":"yellow-taxi","_id":"AWesW0cJYEmXIw2Bonx4","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"created":true,"_source":{"birthday":"1959-06-22","license":"B","name":"Sirkis","_kuzzle_info":{"author":"-1","createdAt":1544784922373,"updatedAt":null,"updater":null,"active":true,"deletedAt":null}},"_meta":{"author":"-1","createdAt":1544784922373,"updatedAt":null,"updater":null,"active":true,"deletedAt":null}}
 ```
 
 You can perform other actions such as [delete]({{ site_base_path }}sdk-reference/go/1/document/delete),
-[replace]({{ site_base_path }}sdk-reference/go/1/document/replace) or [search]({{ site_base_path }}sdk-reference/go/1/document/search) documents. There are also other ways to interact with Kuzzle like our [Admin Console]({{ site_base_path }}guide/1/essentials/installing-console/), the [Kuzzle HTTP API]({{ site_base_path }}api/1/essentials/connecting-to-kuzzle/) or by using your [own protocol](protocols/1/essentials/getting-started/).
+[replace]({{ site_base_path }}sdk-reference/go/1/document/replace) or [search]({{ site_base_path }}sdk-reference/go/1/document/search) documents. There are also other ways to interact with Kuzzle like our [Admin Console]({{ site_base_path }}guide/1/essentials/installing-console/), the [Kuzzle HTTP API]({{ site_base_path }}api/1/essentials/connecting-to-kuzzle/) or by using your [own protocol]({{ site_base_path }}protocols/1/essentials/getting-started/).
 
 Now you know how to:
 * Store documents in a Kuzzle server, and access those
 
 ## Subscribe to realtime document notifications (pub/sub)
 
-Time to use realtime with Kuzzle. Create a new file `realtime.go` with the following code:
+Time to use realtime with Kuzzle. Create a new file `realtime.cpp` with the following code:
 
 [snippet=realtime]
 
@@ -128,7 +122,8 @@ This program subscribes to changes made to documents with a `license` field set 
 Run your program:
 
 ```bash
-$ go run realtime.go
+$ g++ -o realtime realtime.cpp -I${KUZZLE_SDK_PATH}/include -L${KUZZLE_SDK_PATH}/lib -lkuzzlesdk -lpthread
+$ LD_LIBRARY_PATH=${KUZZLE_SDK_PATH}/lib/ ./realtime
 Connected!
 Successfully subscribing!
 New document added to yellow-taxi collection!

--- a/src/sdk-reference/java/1/getting-started/index.md
+++ b/src/sdk-reference/java/1/getting-started/index.md
@@ -33,6 +33,11 @@ on our [download
 plateform](https://dl.kuzzle.io/sdk/java/master/index.html). Download
 and add it to your classpath.
 
+<div class="alert alert-info">
+Following examples are made to be execute without any IDE.
+If you're using Eclipse, IntelliJ or another Java IDE. You'll need to add the SDK as a project dependency in your classpath as you would make as usual.
+</div>
+
 ## First connection
 
 Initialize a new Java project, create a `gettingstartedfirstconnection.java` file and start by adding the code below:
@@ -77,7 +82,7 @@ New document added to yellow-taxi collection!
 ```
 
 You can perform other actions such as [delete]({{ site_base_path }}sdk-reference/go/1/document/delete),
-[replace]({{ site_base_path }}sdk-reference/go/1/document/replace) or [search]({{ site_base_path }}sdk-reference/go/1/document/search) documents. There are also other ways to interact with Kuzzle like our [Admin Console]({{ site_base_path }}guide/1/essentials/installing-console/), the [Kuzzle HTTP API]({{ site_base_path }}api/1/essentials/connecting-to-kuzzle/) or by using your [own protocol](protocols/1/essentials/getting-started/).
+[replace]({{ site_base_path }}sdk-reference/go/1/document/replace) or [search]({{ site_base_path }}sdk-reference/go/1/document/search) documents. There are also other ways to interact with Kuzzle like our [Admin Console]({{ site_base_path }}guide/1/essentials/installing-console/), the [Kuzzle HTTP API]({{ site_base_path }}api/1/essentials/connecting-to-kuzzle/) or by using your [own protocol]({{ site_base_path }}protocols/1/essentials/getting-started/).
 
 Now you know how to:
 * Store documents in a Kuzzle Server, and access those

--- a/src/sdk-reference/java/1/getting-started/index.md
+++ b/src/sdk-reference/java/1/getting-started/index.md
@@ -34,8 +34,8 @@ plateform](https://dl.kuzzle.io/sdk/java/master/index.html). Download
 and add it to your classpath.
 
 <div class="alert alert-info">
-Following examples are made to be execute without any IDE.
-If you're using Eclipse, IntelliJ or another Java IDE. You'll need to add the SDK as a project dependency in your classpath as you would make as usual.
+The following examples are made to be executed without any IDE.
+If you're using Eclipse, IntelliJ or another Java IDE, you need to add the SDK as a project dependency in your classpath.
 </div>
 
 ## First connection

--- a/src/sdk-reference/js/6/realtime/subscribe/index.md
+++ b/src/sdk-reference/js/6/realtime/subscribe/index.md
@@ -6,7 +6,7 @@ description: Subscribe to real-time notifications
 
 # subscribe
 
-Subscribes by providing a set of filters: messages, document changes and, optionally, user events matching the provided filters will generate [real-time notifications]({{site_base_path}}api/1/essentials/real-time), sent to you in real-time by Kuzzle.
+Subscribes by providing a set of filters: messages, document changes and, optionally, user events matching the provided filters will generate [real-time notifications]({{site_base_path}}api/1/essentials/notifications/), sent to you in real-time by Kuzzle.
 
 ## Arguments
 


### PR DESCRIPTION
## What does this PR do?
Thanks to @berthieresteban and @Yoann-Abbes, this PR fix and enhance our documentation:
* Wrong request/response example in API document/replace route
* Getting started C++:
  * Replace `gcc` by `g++` and update compilation instructions following this.
  * Add `LD_LIBRARY_PATH=${KUZZLE_SDK_PATH}/lib/ ` in execution instructions.
  * Fix copypasta error in realtime part.
* Getting started Java:
  * Add warning for Java IDE users about getting started examples.
  * Fix dead link.
* Fix dead link in js6 subscribe method 

### How should this be manually tested?

[Netlify](https://deploy-preview-226--kuzzle-doc-v2.netlify.com/)